### PR TITLE
Ignore string refs if server-side rendered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-    - "node"
     - "8"
     - "7"
     - "6"

--- a/packages/melody-idom/src/attributes.ts
+++ b/packages/melody-idom/src/attributes.ts
@@ -114,7 +114,7 @@ const updateAttribute = function(el, name, value) {
         }
     } else if (name === 'ref') {
         const old = attrs.ref;
-        if (old) {
+        if (old && old.disposer) {
             if (old.creator === value) {
                 return;
             }


### PR DESCRIPTION
String refs are deprecated but still supported. If server-side rendered as melody hydrates the DOM it should ignore these previous string refs.