### PR TITLE
fix: add transform-object-rest-spread plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,9 @@
         "lodash"
     ],
     "env": {
+        "development": {
+            "presets": [["es2015", {modules: false, loose: true}], "stage-1", "react"],
+        },
         "production": {
             "presets": [["es2015", {modules: false, loose: true}], "stage-1", "react"],
             "plugins": ["transform-inline-environment-variables"]


### PR DESCRIPTION
I was getting following error while building melody using `yarn run build`
```
lerna ERR!
lerna ERR! Error: (babel plugin) /Users/ayush/github/melody/packages/melody-hoc/src/withHandlers.js: Unexpected token (76:16)
lerna ERR! undefined (76:16)
lerna ERR!
```

I think, It is because of transform-object-rest-spread so this PR includes addition of the ransform-object-rest-spread plugin. 

Thanks.