### PR TITLE
melody logger

### DIFF
--- a/packages/melody-compiler/src/state/State.js
+++ b/packages/melody-compiler/src/state/State.js
@@ -27,6 +27,10 @@ export default class State {
         this.options = {
             generateKey: true,
             projectRoot: undefined,
+            // eslint-disable-next-line
+            warn: console.warn.bind(console),
+            // eslint-disable-next-line
+            error: console.error.bind(console),
         };
         this.program = {
             type: 'Program',
@@ -74,6 +78,20 @@ export default class State {
             errorMessage += '\n\n' + advice;
         }
         throw new Error(errorMessage);
+    }
+
+    warn(message, pos, advice, length = 1) {
+        let warnMessage = `${message}\n`;
+        warnMessage += codeFrame({
+            rawLines: this.source,
+            lineNumber: pos.line,
+            colNumber: pos.column,
+            length,
+        });
+        if (advice) {
+            warnMessage += '\n\n' + advice;
+        }
+        this.options.warn(warnMessage);
     }
 
     markIdentifier(name) {

--- a/packages/melody-loader/src/index.js
+++ b/packages/melody-loader/src/index.js
@@ -24,7 +24,11 @@ module.exports = function loader(content) {
     const loaderOptions = getOptions(this) || {
         plugins: [],
     };
-
+    // configuring logger using webpack logging mechanism.
+    CoreExtension.options = {
+        warn: this.emitWarning,
+        error: this.emitError,
+    };
     const args = [this.resourcePath, content, CoreExtension];
     if (loaderOptions.plugins) {
         for (const pluginName of loaderOptions.plugins) {


### PR DESCRIPTION
**Type**:  Feature / Unit Tests

The following has been addressed in the PR:
- a logger abstraction in `melody-logger`
- `warn` method in [state](https://github.com/trivago/melody/blob/27745d7531aed047f1491c33b9306adb7df87993/packages/melody-compiler/src/state/State.js#L65)
- changes in test cases
- In `melody-logger` I have added `lib` in git history (`melody-logger` is not on npm registry)
- prettier changes
- Resolves #12 