### PR TITLE
melody-jest-transform: custom babel plugin spec

### DIFF
--- a/packages/melody-jest-transform/__tests__/__snapshots__/customTransformSpec.js.snap
+++ b/packages/melody-jest-transform/__tests__/__snapshots__/customTransformSpec.js.snap
@@ -23,6 +23,34 @@ exports[`Custom transformer should throw error if it cannot find a config in reg
 
 exports[`Custom transformer should transpile with jest's process function 1`] = `undefined`;
 
+exports[`Custom transformer should work with custom babelConfig and melody-plugins 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+exports._template = undefined;
+exports.default = Test;
+
+var _melodyIdom = require(\\"melody-idom\\");
+
+const _template = exports._template = {};
+
+_template.render = function (_context) {
+  (0, _melodyIdom.elementOpen)(\\"div\\", null, null);
+  (0, _melodyIdom.text)(\\"test\\");
+  (0, _melodyIdom.elementClose)(\\"div\\");
+};
+
+if (\\"test\\" !== \\"production\\") {
+  _template.displayName = \\"Test\\";
+}
+
+function Test(props) {
+  return _template.render(props);
+}"
+`;
+
 exports[`Custom transformer should work with default babelconfig and melody-plugins 1`] = `
 "\\"use strict\\";
 

--- a/packages/melody-jest-transform/__tests__/customTransformSpec.js
+++ b/packages/melody-jest-transform/__tests__/customTransformSpec.js
@@ -63,6 +63,17 @@ describe('Custom transformer', () => {
                 },
             },
         ];
+
+        const babel = {
+            env: {
+                test: {
+                    presets: ['node6', 'stage-1'],
+                    plugins: ['transform-inline-environment-variables'],
+                },
+            },
+        };
+
+        test('test.twig', { plugins, babel });
     });
 
     it('should throw error if it cannot find a config in regular locations', () => {
@@ -70,7 +81,7 @@ describe('Custom transformer', () => {
         mockedFindBabel.sync.mockImplementationOnce(() => false);
         const regularFixture = getFixture('test.twig');
         expect(() =>
-            transformer(regularFixture, 'test.twig'),
+            transformer(regularFixture, 'test.twig')
         ).toThrowErrorMatchingSnapshot();
     });
 


### PR DESCRIPTION
**Type**: Unit Test

The following has been addressed in the PR:
- complete a spec in 
https://github.com/trivago/melody/blob/27745d7531aed047f1491c33b9306adb7df87993/packages/melody-jest-transform/__tests__/customTransformSpec.js#L55