### PR TITLE
melody-types: adds missing constant type

### DIFF
--- a/packages/melody-types/src/index.js
+++ b/packages/melody-types/src/index.js
@@ -146,6 +146,7 @@ export class ConstantValue extends Node {
         return `Const(${this.value})`;
     }
 }
+type(ConstantValue, 'ConstantValue');
 alias(ConstantValue, 'Expression', 'Literal', 'Immutable');
 
 export class StringLiteral extends ConstantValue {}


### PR DESCRIPTION
**Type**: Bug

The following has been addressed in the PR:
- `type.prototype.type` is undefined for `constantValue`.
https://github.com/trivago/melody/blob/e1557751063a949c9738728710609a7d052f4fda/packages/melody-types/src/index.js#L97
- `console.log(IS_ALIAS_OF[alias])` outputs `undefined` for missing type. <img width="893" alt="screen shot 2018-01-09 at 9 56 23 pm" src="https://user-images.githubusercontent.com/6918450/34731362-21e06df6-f588-11e7-8180-4578951ad244.png">
- This PR adds the missing type.
  