### PR TITLE
Chore: Add Community guidelines for github repository

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,23 @@
+#### Explain the problem
+
+
+#### Expected Behaviour
+
+
+#### Actual Behaviour
+
+
+#### Steps to reproduce
+
+
+#### Provide a repository that reproduces issue if possible
+
+
+#### Provide your Environment details
+- Node version:
+
+- Operating System:
+
+- melody version:
+
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at efe-gurkan.yalaman@trivago.com ,
+james.bell@trivago.com . All complaints will be reviewed and investigated and
+will result in a response that is deemed necessary and appropriate to the
+circumstances. The project team is obligated to maintain confidentiality with
+regard to the reporter of an incident.  Further details of specific enforcement
+policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to melody
+
+Thank you for contributing to `melody`!
+
+This project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md) By participating you agree to comply with its terms.
+
+#### Table Of Contents
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Improve Documentation](#improve-documentation)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Writing Code](#writing-code)
+  * [Pull Requests](#pull-requests)
+
+
+## How can I contribute?
+
+### Improve documentation
+Most simple way to contribute is improving our documentation. Fixing typo's, fixing errors, explaining something better,
+more examples etc. If your work would be a big change, open an issue first. For smaller changes feel free to open a PR
+directly.
+
+Use common sense to decide if you need an issue or not. Generally if you change more than a few paragraphs, multiple
+files etc, it is better to open an issue and explain your change.
+
+### Reporting Bugs
+
+If you encounter any issues with `melody` don't hesitate to report it. While reporting your bug make sure you
+follow the guidelines below. It helps maintainers to understand and reproduce the problem.
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Provide configuration you used** which is critical for reproducing problem in most cases.
+* **Provide system details you used** to identify if the problem is system specific. I.e: operating system, node version, webpack version you used etc.
+* **Describe the exact steps which reproduce the problem** in as many details as possible.
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+
+### Writing code
+
+Find an issue you want to work on, or if you have your own idea create an issue. You might find an issue assigned. Double-check
+if somebody else is working on the same issue.
+
+#### Local development
+
+It usually is a good idea to create a dummy repository to run your changes.
+
+While writing code make sure you followjthis guidelines:
+* Use 4 space indentation.
+* Always use strict equality checks `===` instead of `==`.
+* Make sure your code runs on node 6.
+* Make sure you run `prettier` and `ESLint`.
+* Write tests and run them. Check coverage before submitting.
+* Write documentation for your code.
+
+### Pull Requests
+
+* Non-trivial changes are often best discussed in an issue first, to prevent you from doing unnecessary work.
+* For ambitious tasks, you should try to get your work in front of the community for feedback as soon as possible. Open a pull request as soon as you have done the minimum needed to demonstrate your idea. At this early stage, don't worry about making things perfect, or 100% complete. Add a [WIP] prefix to the title, and describe what you still need to do. This lets reviewers know not to nit-pick small details or point out improvements you already know you need to make.
+* New features should be accompanied with tests and documentation.
+* Don't include unrelated changes.
+* Make the pull request from a [topic branch](https://github.com/dchelimsky/rspec/wiki/Topic-Branches), not master.
+* Use a clear and descriptive title for the pull request and commits.
+* Write a convincing description of why we should land your pull request. It's your job to convince us. Answer "why" it's needed and provide use-cases.
+* You might be asked to do changes to your pull request. There's never a need to open another pull request. [Just update the existing one.](https://github.com/RichardLitt/knowledge/blob/master/github/amending-a-commit-guide.md)
+* Be patient, we might not find time to check on your pull requests immediately. It will be checked eventually.


### PR DESCRIPTION
Add github issue template we use for parallel-webpack. Changed a bit to
make it relevant for melody

Add Code of Conduct

Add Contributing guidelines.