### PR TITLE
Skip over all empty elements

### DIFF
--- a/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -1515,7 +1515,7 @@ exports[`Compiler should correctly transform macros.template 1`] = `
 "
 import { input as input_field } from \\"forms.html\\";
 import * as foo from \\"forms.html\\";
-import { elementOpenStart, elementOpenEnd, attr, elementClose } from \\"melody-idom\\";
+import { elementOpenStart, elementOpenEnd, attr, skip, elementClose } from \\"melody-idom\\";
 export const _template = {};
 export function input(name, value, type, size, ...varargs) {
     elementOpenStart(\\"input\\", null, null, \\"type\\", type != null && type !== '' ? type : \\"text\\", \\"name\\", name, \\"value\\", value, \\"size\\", size != null && size !== '' ? size : 20);
@@ -1527,6 +1527,7 @@ export function input(name, value, type, size, ...varargs) {
     }
 
     elementOpenEnd();
+    skip();
     elementClose(\\"input\\");
 }
 
@@ -1816,7 +1817,7 @@ export default function Raw(props) {
 
 exports[`Compiler should correctly transform ref.template 1`] = `
 "
-import { text, ref, elementOpen, elementClose, elementVoid, elementOpenStart, elementOpenEnd, attr } from \\"melody-idom\\";
+import { text, ref, elementOpen, elementClose, elementVoid, elementOpenStart, elementOpenEnd, attr, skip } from \\"melody-idom\\";
 export const _template = {};
 const _statics = [\\"class\\", \\"bar\\", \\"ref\\", ref(\\"span\\")],
       _statics$1 = [\\"class\\", \\"icon-heart\\", \\"ref\\", ref(\\"heart-icon\\")],
@@ -1841,6 +1842,7 @@ _template.render = function (_context) {
     }
 
     elementOpenEnd();
+    skip();
     elementClose(\\"span\\");
     elementOpenStart(\\"span\\", \\"Jq{7=IP\\", _statics$4);
 
@@ -2260,7 +2262,7 @@ export default function Test(props) {
 `;
 
 exports[`Compiler when converting should support dynamic attributes 1`] = `
-"import { elementOpenStart, elementOpenEnd, attr, elementClose } from \\"melody-idom\\";
+"import { elementOpenStart, elementOpenEnd, attr, skip, elementClose } from \\"melody-idom\\";
 export const _template = {};
 const _statics = [\\"class\\", \\"foo\\"];
 
@@ -2274,6 +2276,7 @@ _template.render = function (_context) {
   }
 
   elementOpenEnd();
+  skip();
   elementClose(\\"div\\");
 };
 

--- a/packages/melody-idom/__tests__/ConditionalRenderingSpec.ts
+++ b/packages/melody-idom/__tests__/ConditionalRenderingSpec.ts
@@ -114,18 +114,18 @@ describe('conditional rendering', () => {
             if (condition) {
                 elementOpen(
                     'span',
-                    null,
+                    'conditional',
                     null,
                     'id',
                     'conditional-one',
                     'data-foo',
-                    'foo',
+                    'foo'
                 );
                 elementVoid('span');
                 elementClose('span');
             }
 
-            elementVoid('span', null, null, 'id', 'two');
+            elementVoid('span', 'last', null, 'id', 'two');
             elementClose('div');
         }
 

--- a/packages/melody-idom/src/virtual_elements.ts
+++ b/packages/melody-idom/src/virtual_elements.ts
@@ -21,6 +21,7 @@ import {
     text as coreText,
     raw as coreRaw,
     currentComponent,
+    skip,
 } from './core';
 import { updateAttribute } from './attributes';
 import { getData } from './node_data';
@@ -230,6 +231,7 @@ var elementClose = function(tag) {
  */
 var elementVoid = function(tag, key, statics, var_args) {
     elementOpen.apply(null, arguments);
+    skip();
     return elementClose(tag);
 };
 

--- a/packages/melody-plugin-idom/src/visitors/idom.js
+++ b/packages/melody-plugin-idom/src/visitors/idom.js
@@ -246,6 +246,8 @@ function openDynamicAttributesElement(
         if (ref) {
             replacements.push(callIdomFunction(state, 'ref', [ref]));
         }
+        // insert skip to jump over any children
+        replacements.push(callIdomFunction(state, 'skip', []));
         // we handle closing the tag here since there is
         // no equivalent of 'elementVoid' when using dynamic attributes
         replacements.push(


### PR DESCRIPTION
This change allows easier control over empty elements from outside of
Melody and will make it easier for custom elements that don't use shadow
DOM or for ref handlers to inject and control their own content without
having to worry about a re-render removing the inserted children.