### PR TITLE
Fix not in operator

### DIFF
--- a/packages/melody-compiler/__tests__/LexerSpec.js
+++ b/packages/melody-compiler/__tests__/LexerSpec.js
@@ -102,7 +102,7 @@ describe('Lexer', () => {
     describe('in expression state', function() {
         it('should parse an expression that is a string', () => {
             var lexer = new Lexer(
-                    new CharStream(' hello {{- "test " -}} world'),
+                    new CharStream(' hello {{- "test " -}} world')
                 ),
                 token = lexer.next();
             expect(token.type).to.eql(Types.TEXT);
@@ -131,7 +131,7 @@ describe('Lexer', () => {
 
         it('should parse an expression that is a string and contains escaping', () => {
             var lexer = new Lexer(
-                    new CharStream("hello {{ 'test\\'n this' }}world"),
+                    new CharStream("hello {{ 'test\\'n this' }}world")
                 ),
                 token = lexer.next();
             expect(token.type).to.eql(Types.TEXT);
@@ -416,6 +416,31 @@ describe('Lexer', () => {
             expect(token.text).to.equal('}}');
             expect(token.type).to.equal(Types.EXPRESSION_END);
         });
+
+        it('should match a not expression', () => {
+            var lexer = new Lexer(new CharStream('{{ not invalid }}')),
+                token;
+            lexer.addOperators('not', 'not in');
+            token = lexer.next();
+            expect(token.text).to.equal('{{');
+            expect(token.type).to.equal(Types.EXPRESSION_START);
+            token = lexer.next();
+            expect(token.type).to.equal(Types.WHITESPACE);
+            token = lexer.next();
+            expect(token.text).to.equal('not');
+            expect(token.type).to.equal(Types.OPERATOR);
+            token = lexer.next();
+            expect(token.type).to.equal(Types.WHITESPACE);
+            token = lexer.next();
+            expect(token.text).to.equal('invalid');
+            expect(token.type).to.equal(Types.SYMBOL);
+            token = lexer.next();
+            expect(token.type).to.equal(Types.WHITESPACE);
+            token = lexer.next();
+            expect(token.text).to.equal('}}');
+            expect(token.type).to.equal(Types.EXPRESSION_END);
+        });
+
         //it('should match a test by length', () => {
         //    var lexer = new Lexer(new CharStream(`{{ foo is divisible by bar }}`)),
         //        token;
@@ -463,7 +488,7 @@ describe('Lexer', () => {
 
         it('should match an extends tag', function() {
             var lexer = new Lexer(
-                    new CharStream('{% extends "foo.html.twig" %}'),
+                    new CharStream('{% extends "foo.html.twig" %}')
                 ),
                 token;
             lexer.addOperators('+');
@@ -524,7 +549,7 @@ describe('Lexer', () => {
 
         it('should match simple HTML attributes', () => {
             var lexer = new Lexer(
-                    new CharStream('<div class="foo">Test</div>'),
+                    new CharStream('<div class="foo">Test</div>')
                 ),
                 token;
             token = lexer.next();
@@ -572,7 +597,7 @@ describe('Lexer', () => {
 
         it('should match simple HTML attributes with expression value', () => {
             var lexer = new Lexer(
-                    new CharStream('<div class="{{name}}">Test</div>'),
+                    new CharStream('<div class="{{name}}">Test</div>')
                 ),
                 token;
             token = lexer.next();
@@ -626,7 +651,7 @@ describe('Lexer', () => {
 
         it('should match HTML attributes with mixed values', () => {
             var lexer = new Lexer(
-                    new CharStream('<div class="test-{{name}} foo">Test</div>'),
+                    new CharStream('<div class="test-{{name}} foo">Test</div>')
                 ),
                 token;
             token = lexer.next();
@@ -687,8 +712,8 @@ describe('Lexer', () => {
         it('should keep quotes in interpolation', () => {
             var lexer = new Lexer(
                     new CharStream(
-                        '{{ even ? \'class="#{evenClass}" data-even\' }}',
-                    ),
+                        '{{ even ? \'class="#{evenClass}" data-even\' }}'
+                    )
                 ),
                 token;
             token = lexer.next();

--- a/packages/melody-compiler/__tests__/__fixtures__/success/not_in.template
+++ b/packages/melody-compiler/__tests__/__fixtures__/success/not_in.template
@@ -1,0 +1,7 @@
+{% if 1 not in elements %}
+    <p>The number 1 is not present in the elements array.</p>
+{% endif %}
+
+{% if not invalid %}
+    <p>All's well.</p>
+{% endif %}

--- a/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -1789,6 +1789,36 @@ export default function MultiInclude(props) {
 "
 `;
 
+exports[`Compiler should correctly transform not in.template 1`] = `
+"
+import { text, elementOpen, elementClose } from \\"melody-idom\\";
+import { includes } from \\"lodash\\";
+export const _template = {};
+
+_template.render = function (_context) {
+    if (!includes(_context.elements, 1)) {
+        elementOpen(\\"p\\", null, null);
+        text(\\"The number 1 is not present in the elements array.\\");
+        elementClose(\\"p\\");
+    }
+
+    if (!_context.invalid) {
+        elementOpen(\\"p\\", null, null);
+        text(\\"All's well.\\");
+        elementClose(\\"p\\");
+    }
+};
+
+if (process.env.NODE_ENV !== \\"production\\") {
+    _template.displayName = \\"NotIn\\";
+}
+
+export default function NotIn(props) {
+    return _template.render(props);
+}
+"
+`;
+
 exports[`Compiler should correctly transform raw.template 1`] = `
 "
 import { rawString, raw, text } from \\"melody-idom\\";

--- a/packages/melody-parser/src/Lexer.js
+++ b/packages/melody-parser/src/Lexer.js
@@ -370,8 +370,15 @@ export default class Lexer {
         for (let i = 0, ops = this[OPERATORS], len = ops.length; i < len; i++) {
             const op = ops[i];
             if (op.length > longestMatchingOperator.length && input.match(op)) {
-                longestMatchingOperator = op;
-                longestMatchEndPos = input.mark();
+                const cc = input.lac(0);
+
+                // prevent mixing up operators with symbols (e.g. matching
+                // 'not in' in 'not invalid').
+                if (op.indexOf(' ') === -1 || !(isAlpha(cc) || isDigit(cc))) {
+                    longestMatchingOperator = op;
+                    longestMatchEndPos = input.mark();
+                }
+
                 input.rewind(start);
             }
         }


### PR DESCRIPTION
This prevents issues like `not invalid` matching the `not in` operator. We only
check for operators that contain a whitespace as those that don't are already
matched as a symbol.