### PR TITLE
Fix draggable attribute to allow "false" as value

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         },
         {
             "path": "./packages/melody-idom/lib/index.js",
-            "maxSize": "4.61 kB"
+            "maxSize": "4.63 kB"
         },
         {
             "path": "./packages/melody-hoc/lib/index.js",

--- a/packages/melody-idom/src/attributes.ts
+++ b/packages/melody-idom/src/attributes.ts
@@ -159,6 +159,7 @@ const updateAttribute = function(el, name, value) {
     } else if (
         name !== 'list' &&
         name !== 'type' &&
+        name !== 'draggable' &&
         !(el.ownerSVGElement || el.localName === 'svg') &&
         name in el
     ) {


### PR DESCRIPTION
This attribute is an enumerated one and not a Boolean one. This means that the explicit usage of one of the values true or false is mandatory and that a shorthand like <label draggable>Example Label</label> is not allowed. The correct usage is <label draggable="true">Example Label</label>.
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/draggable