### PR TITLE
Introduce new skip-if block

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
         'packages/melody-component/**',
         'packages/melody-loader/**',
         'packages/melody-plugin-jsx/**',
+        'packages/melody-plugin-skip-if/**',
         'packages/melody-jest-transform/**',
         'packages/melody-redux/**',
         'packages/melody-util/**',

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         },
         {
             "path": "./packages/melody-idom/lib/index.js",
-            "maxSize": "4.64 kB"
+            "maxSize": "4.65 kB"
         },
         {
             "path": "./packages/melody-hoc/lib/index.js",

--- a/packages/melody-plugin-skip-if/__tests__/SkipIfSpec.js
+++ b/packages/melody-plugin-skip-if/__tests__/SkipIfSpec.js
@@ -27,6 +27,12 @@ test('skip if defined should fail if parent element is not a custom element', ()
     ).toMatchSnapshot();
 });
 
+test('skip if defined should fail if target is unknown', () => {
+    expect(
+        render(`<div>{% skip if notHavingFun %}hello world{% endskip %}</div>`)
+    ).toMatchSnapshot();
+});
+
 function render(template) {
     try {
         const jsTemplate = compile(

--- a/packages/melody-plugin-skip-if/__tests__/SkipIfSpec.js
+++ b/packages/melody-plugin-skip-if/__tests__/SkipIfSpec.js
@@ -1,0 +1,43 @@
+import { compile, toString } from 'melody-compiler';
+import { extension as coreExtension } from 'melody-extension-core';
+import idomPlugin from 'melody-plugin-idom';
+import skipIfPlugin from '../src';
+
+test('skip if client should skip content', () => {
+    expect(
+        render(`<div>{% skip if client %}hello world{% endskip %}</div>`)
+    ).toMatchSnapshot();
+});
+
+test('skip if server should be ignored', () => {
+    expect(
+        render(`<div>{% skip if server %}hello world{% endskip %}</div>`)
+    ).toMatchSnapshot();
+});
+
+test('skip if defined should check if parent element is defined', () => {
+    expect(
+        render(`<x-div>{% skip if defined %}hello world{% endskip %}</x-div>`)
+    ).toMatchSnapshot();
+});
+
+test('skip if defined should fail if parent element is not a custom element', () => {
+    expect(
+        render(`<div>{% skip if defined %}hello world{% endskip %}</div>`)
+    ).toMatchSnapshot();
+});
+
+function render(template) {
+    try {
+        const jsTemplate = compile(
+            'test.twig',
+            template,
+            coreExtension,
+            idomPlugin,
+            skipIfPlugin
+        );
+        return toString(jsTemplate, template).code;
+    } catch (e) {
+        return e.message;
+    }
+}

--- a/packages/melody-plugin-skip-if/__tests__/__snapshots__/SkipIfSpec.js.snap
+++ b/packages/melody-plugin-skip-if/__tests__/__snapshots__/SkipIfSpec.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`skip if client should skip content 1`] = `
+"import { skip, elementOpen, elementClose } from \\"melody-idom\\";
+export const _template = {};
+
+_template.render = function (_context) {
+  elementOpen(\\"div\\", null, null);
+  skip();
+  elementClose(\\"div\\");
+};
+
+if (process.env.NODE_ENV !== \\"production\\") {
+  _template.displayName = \\"Test\\";
+}
+
+export default function Test(props) {
+  return _template.render(props);
+}"
+`;
+
+exports[`skip if defined should check if parent element is defined 1`] = `
+"import { text, skip, elementOpen, elementClose } from \\"melody-idom\\";
+export const _template = {};
+
+_template.render = function (_context) {
+  elementOpen(\\"x-div\\", null, null);
+
+  if (customElements.get(\\"x-div\\") !== undefined) {
+    skip();
+  } else {
+    text(\\"hello world\\");
+  }
+
+  elementClose(\\"x-div\\");
+};
+
+if (process.env.NODE_ENV !== \\"production\\") {
+  _template.displayName = \\"Test\\";
+}
+
+export default function Test(props) {
+  return _template.render(props);
+}"
+`;
+
+exports[`skip if defined should fail if parent element is not a custom element 1`] = `
+"skip if defined can only be used inside of a custom element
+> 1 | <div>{% skip if defined %}hello world{% endskip %}</div>
+    |  ^^^
+
+Custom Element must contain a \\"-\\" within their name but \\"div\\" does not seem to contain one.
+More information about custom elements can be found here: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements"
+`;
+
+exports[`skip if server should be ignored 1`] = `
+"import { text, elementOpen, elementClose } from \\"melody-idom\\";
+export const _template = {};
+
+_template.render = function (_context) {
+  elementOpen(\\"div\\", null, null);
+  text(\\"hello world\\");
+  elementClose(\\"div\\");
+};
+
+if (process.env.NODE_ENV !== \\"production\\") {
+  _template.displayName = \\"Test\\";
+}
+
+export default function Test(props) {
+  return _template.render(props);
+}"
+`;

--- a/packages/melody-plugin-skip-if/__tests__/__snapshots__/SkipIfSpec.js.snap
+++ b/packages/melody-plugin-skip-if/__tests__/__snapshots__/SkipIfSpec.js.snap
@@ -53,6 +53,14 @@ Custom Element must contain a \\"-\\" within their name but \\"div\\" does not s
 More information about custom elements can be found here: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements"
 `;
 
+exports[`skip if defined should fail if target is unknown 1`] = `
+"Unknown skip if target
+> 1 | <div>{% skip if notHavingFun %}hello world{% endskip %}</div>
+    |                 ^^^^^^^^^^^^
+
+The target of the skip must be either 'client', 'server' or 'defined' but was \\"notHavingFun\\" instead."
+`;
+
 exports[`skip if server should be ignored 1`] = `
 "import { text, elementOpen, elementClose } from \\"melody-idom\\";
 export const _template = {};

--- a/packages/melody-plugin-skip-if/package.json
+++ b/packages/melody-plugin-skip-if/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "melody-plugin-skip-if",
+  "version": "1.0.3",
+  "description": "",
+  "main": "./lib/index.js",
+  "jsnext:main": "./src/index.js",
+  "scripts": {
+    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "babel-types": "^6.8.1"
+  },
+  "bundledDependencies": [
+    "babel-types"
+  ],
+  "peerDependencies": {
+    "melody-types": "^1.0.0"
+  },
+  "devDependencies": {
+    "rollup-plugin-babel": "^2.6.1"
+  }
+}

--- a/packages/melody-plugin-skip-if/src/index.js
+++ b/packages/melody-plugin-skip-if/src/index.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as t from 'babel-types';
+import { Node, type, alias, visitor } from 'melody-types';
+import template from 'babel-template';
+import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
+
+export class SkipIfBlock extends Node {
+    constructor(target, expressions) {
+        super();
+        this.target = target;
+        this.expressions = expressions;
+    }
+}
+type(SkipIfBlock, 'SkipIfBlock');
+alias(SkipIfBlock, 'Block');
+visitor(SkipIfBlock, 'expressions');
+
+export const SkipIfParser = {
+    name: 'skip',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        tokens.expect(Types.SYMBOL, 'if');
+        const condition = tokens.expect(Types.SYMBOL);
+        tokens.expect(Types.TAG_END);
+
+        const skipIfBlock = new SkipIfBlock(
+            condition.text,
+            parser.parse((tokenText, token, tokens) => {
+                return !!(
+                    token.type === Types.TAG_START &&
+                    tokens.nextIf(Types.SYMBOL, 'endskip')
+                );
+            }).expressions
+        );
+
+        setStartFromToken(skipIfBlock, token);
+        setEndFromToken(skipIfBlock, tokens.expect(Types.TAG_END));
+
+        return skipIfBlock;
+    },
+};
+
+const buildSkipIfDefined = template(`
+if (customElements.get(ELEMENT_NAME) !== undefined) {
+    SKIP
+} else {
+    BODY
+}
+`);
+
+export default {
+    tags: [SkipIfParser],
+    visitors: [
+        {
+            analyse: {
+                SkipIfBlock(path) {
+                    if (path.node.target === 'client') {
+                        path.skip();
+                    }
+                },
+            },
+            convert: {
+                SkipIfBlock: {
+                    enter(path) {
+                        if (path.node.target === 'client') {
+                            //path.skip();
+                            path.replaceWithJS(skip(this));
+                        }
+                    },
+                    exit(path) {
+                        const { target } = path.node;
+                        if (target === 'client') {
+                            path.replaceWithJS(skip(this));
+                        } else if (target === 'server') {
+                            path.replaceWithMultipleJS(
+                                ...path.node.expressions
+                            );
+                        } else if (target === 'defined') {
+                            const el = path.findParentPathOfType('Element');
+                            const elementName = el.node.name;
+                            if (elementName.indexOf('-') === -1) {
+                                this.error(
+                                    'skip if defined can only be used inside of a custom element',
+                                    el.node.loc.start,
+                                    `Custom Element must contain a "-" within their name but "${elementName}" does not seem to contain one.
+More information about custom elements can be found here: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements`,
+                                    elementName.length
+                                );
+                            }
+                            path.replaceWithJS(
+                                buildSkipIfDefined({
+                                    ELEMENT_NAME: t.stringLiteral(elementName),
+                                    SKIP: skip(this),
+                                    BODY: path.node.expressions,
+                                })
+                            );
+                        }
+                    },
+                },
+            },
+        },
+    ],
+};
+
+function skip(state) {
+    return t.expressionStatement(
+        t.callExpression(
+            t.identifier(state.addImportFrom('melody-idom', 'skip')),
+            []
+        )
+    );
+}


### PR DESCRIPTION
Adds support for a new `skip if` block type which can be used to conditionally render either on client or server side or to skip rendering if the containing custom element has already been defined.