### PR TITLE
bugfix/Reintroduce-remove-event-handling

### DIFF
--- a/packages/melody-idom/__tests__/AttributesSpec.ts
+++ b/packages/melody-idom/__tests__/AttributesSpec.ts
@@ -53,7 +53,7 @@ describe('attribute updates', () => {
             patch(container, () =>
                 render({
                     'data-expanded': 'hello',
-                }),
+                })
             );
             const el = container.childNodes[0];
 
@@ -64,7 +64,7 @@ describe('attribute updates', () => {
             patch(container, () =>
                 render({
                     'data-expanded': false,
-                }),
+                })
             );
             const el = container.childNodes[0];
 
@@ -77,7 +77,7 @@ describe('attribute updates', () => {
                     id: undefined,
                     tabindex: undefined,
                     'data-expanded': undefined,
-                }),
+                })
             );
             const el = container.childNodes[0];
 
@@ -90,12 +90,12 @@ describe('attribute updates', () => {
             patch(container, () =>
                 render({
                     'data-expanded': 'foo',
-                }),
+                })
             );
             patch(container, () =>
                 render({
                     'data-expanded': 'bar',
-                }),
+                })
             );
             const el = container.childNodes[0];
 
@@ -106,12 +106,12 @@ describe('attribute updates', () => {
             patch(container, () =>
                 render({
                     'data-foo': 'foo',
-                }),
+                })
             );
             patch(container, () =>
                 render({
                     'data-bar': 'foo',
-                }),
+                })
             );
             const el = container.childNodes[0];
 
@@ -125,12 +125,12 @@ describe('attribute updates', () => {
                     render({
                         'data-foo': 'foo',
                         'data-bar': 'bar',
-                    }),
+                    })
                 );
                 patch(container, () =>
                     render({
                         'data-bar': 'bar',
-                    }),
+                    })
                 );
                 const el = container.childNodes[0];
 
@@ -142,13 +142,13 @@ describe('attribute updates', () => {
                 patch(container, () =>
                     render({
                         'data-bar': 'bar',
-                    }),
+                    })
                 );
                 patch(container, () =>
                     render({
                         'data-foo': 'foo',
                         'data-bar': 'bar',
-                    }),
+                    })
                 );
                 const el = container.childNodes[0];
 
@@ -162,13 +162,13 @@ describe('attribute updates', () => {
                         'data-foo': 'foo',
                         'data-bar': 'bar',
                         'data-baz': 'baz',
-                    }),
+                    })
                 );
                 patch(container, () =>
                     render({
                         'data-bar': 'bar',
                         'data-baz': 'baz',
-                    }),
+                    })
                 );
                 const el = container.childNodes[0];
 
@@ -179,7 +179,7 @@ describe('attribute updates', () => {
                 patch(container, () =>
                     render({
                         'data-bar': 'bar',
-                    }),
+                    })
                 );
                 expect(el.getAttribute('data-foo')).to.equal(null);
                 expect(el.getAttribute('data-bar')).to.equal('bar');
@@ -191,14 +191,14 @@ describe('attribute updates', () => {
                     render({
                         'data-bar': 'bar',
                         'data-baz': 'baz',
-                    }),
+                    })
                 );
                 patch(container, () =>
                     render({
                         'data-foo': 'foo',
                         'data-bar': 'bar',
                         'data-baz': 'baz',
-                    }),
+                    })
                 );
                 const el = container.childNodes[0];
 
@@ -210,7 +210,7 @@ describe('attribute updates', () => {
                     render({
                         'data-foo': 'foo',
                         'data-bar': 'bar',
-                    }),
+                    })
                 );
                 expect(el.getAttribute('data-foo')).to.equal('foo');
                 expect(el.getAttribute('data-bar')).to.equal('bar');
@@ -223,7 +223,7 @@ describe('attribute updates', () => {
                 render({
                     'data-foo': 'foo',
                     'data-bar': 'bar',
-                }),
+                })
             );
             patch(container, () => render({}));
             const el = container.childNodes[0];
@@ -231,6 +231,31 @@ describe('attribute updates', () => {
             expect(el.getAttribute('data-foo')).to.equal(null);
             expect(el.getAttribute('data-bar')).to.equal(null);
         });
+    });
+
+    it('should add string event listeners', () => {
+        let count = 0;
+        const old = window.handler;
+        window.handler = () => count++;
+        patch(
+            container,
+            () => {
+                elementVoid('button', 'test', null, 'onclick', 'handler();');
+            },
+            {}
+        );
+        const el = container.childNodes[0];
+        el.click();
+        patch(
+            container,
+            () => {
+                elementVoid('button', 'test', null, 'onclick', undefined);
+            },
+            {}
+        );
+        el.click();
+        expect(count).to.equal(1);
+        window.handler = old;
     });
 
     describe('for function attributes', () => {
@@ -252,6 +277,29 @@ describe('attribute updates', () => {
             const el = container.childNodes[0];
 
             expect(el.fn).to.equal(fn);
+        });
+
+        it('should remove event listeners', () => {
+            let count = 0;
+            const handler = () => count++;
+            patch(
+                container,
+                () => {
+                    elementVoid('button', 'test', null, 'onclick', handler);
+                },
+                {}
+            );
+            const el = container.childNodes[0];
+            el.click();
+            patch(
+                container,
+                () => {
+                    elementVoid('button', 'test', null, 'onclick', undefined);
+                },
+                {}
+            );
+            el.click();
+            expect(count).to.equal(1);
         });
     });
 
@@ -295,7 +343,7 @@ describe('attribute updates', () => {
             });
             const el = container.childNodes[0].childNodes[0];
             expect(
-                el.getAttributeNS('http://www.w3.org/1999/xlink', 'href'),
+                el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
             ).to.equal('#foo');
         });
 

--- a/packages/melody-idom/src/attributes.ts
+++ b/packages/melody-idom/src/attributes.ts
@@ -140,18 +140,22 @@ const updateAttribute = function(el, name, value) {
         }
         return;
     } else if (name[0] === 'o' && name[1] === 'n') {
-        if (typeof value === 'function') {
-            let useCapture = name !== (name = name.replace(/Capture$/, ''));
-            name = name.toLowerCase().substring(2);
-            if (value) {
-                if (!attrs[name])
-                    el.addEventListener(name, eventProxy, useCapture);
-            } else {
-                el.removeEventListener(name, eventProxy, useCapture);
-            }
-            (el._listeners || (el._listeners = {}))[name] = value;
-        } else {
+        if (typeof value === 'string') {
             applyAttributeTyped(el, name, value);
+        } else {
+            let eventName = name.replace(/Capture$/, '');
+            let useCapture = name !== eventName;
+            eventName = eventName.toLowerCase().substring(2);
+            if (value) {
+                if (!attrs[name]) {
+                    el.addEventListener(eventName, eventProxy, useCapture);
+                }
+            } else if (typeof attrs[name] === 'string') {
+                el.removeAttribute(name);
+            } else {
+                el.removeEventListener(eventName, eventProxy, useCapture);
+            }
+            (el._listeners || (el._listeners = {}))[eventName] = value;
         }
     } else if (
         name !== 'list' &&


### PR DESCRIPTION
Fix for unremoved event handling(#9) was fixed in #11 previously. Due to
an issue while removing string event listener I had to revert it. This
commit reintroduces the fixes done in that PR and fixes the bug in
removal case.