### PR TITLE
Fixed Typo in call to date filter

### DIFF
--- a/packages/melody-extension-core/src/visitors/filters.js
+++ b/packages/melody-extension-core/src/visitors/filters.js
@@ -141,7 +141,7 @@ export default {
         // Not really happy about this since moment.js could well be incompatible with
         // the default twig behaviour
         // might need to switch to an actual strftime implementation
-        path.repalceWithJS(
+        path.replaceWithJS(
             t.callExpression(
                 t.callExpression(
                     t.identifier(path.state.addDefaultImportFrom('moment')),

--- a/packages/melody-plugin-jsx/__tests__/__fixtures__/success/filters.template
+++ b/packages/melody-plugin-jsx/__tests__/__fixtures__/success/filters.template
@@ -1,0 +1,38 @@
+{% set myData = {
+    "test": "value",
+    "meaningOfLife": 42,
+    "True" : false
+} %}
+{% set myArray = ["This", "is", "an", "array"] %}
+
+<ul class="filters">
+    <li>{{ 1.5 | abs }}</li>
+    <li>{{ myArray | batch(2, 'batch') }}</li>
+    <li>{{ "capitalise" | capitalize }}</li>
+    <li>{{ "Test String" | convert_encoding('UTF-8', 'ASCII') | raw }}</li>
+    <li>{{ "2018-03-01" | date_modify("+1 day") | date('Y-m-d') }}</li>
+    <li>{{ elephant | default('elephant') }}</li>
+    <li>{{ "<div>HTML</div>" | escape }}</li>
+    <li>{{ myArray | first }}</li>
+    <li>{{ "I like %s, it is %s" | format("Twig", "nice") }}</li>
+    <li>{{ [1, 2, 3] | join('|') }}</li>
+    <li>{{ myData | json_encode() | raw }}</li>
+    <li>{{ myData | keys }}</li>
+    <li>{{ myArray | last }}</li>
+    <li>{{ myArray | length }}</li>
+    <li>{{ "Lower" | lower }}</li>
+    <li>{{ myArray | merge(["Yes"]) | length }}</li>
+    <li>{{ "\nThis is a new line\nAnd this" | nl2br | raw }}</li>
+    <li>{{ 9800.333 | number_format(2, '.', ',') }}</li>
+    <li>{{ "I like fish" | replace({'fish': 'meat'}) }}</li>
+    <li>{{ myArray | reverse }}</li>
+    <li>{{ 42.55 | round }}</li>
+    <li>{{ "12345" | slice(1, 3) }}</li>
+    <li>{{ myArray | sort }}</li>
+    <li>{{ "one, two, three, four, five" | split(',' , 3) }}</li>
+    <li>{{ "<div>HTML</div>" | striptags }}</li>
+    <li>{{ "Huzzah for twig!" | title }}</li>
+    <li>{{ "  I like Twig.  " | trim }}</li>
+    <li>{{ "Upper" | upper }}</li>
+    <li>{{ "path-seg*ment" | url_encode }}</li>
+</ul>

--- a/packages/melody-plugin-jsx/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-plugin-jsx/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -152,6 +152,42 @@ export default function Extends(props) {
 "
 `;
 
+exports[`Compiler should correctly transform filters.template 1`] = `
+"
+import temp from \\"moment\\";
+import { capitalize, first, keys, last } from \\"lodash\\";
+import { batch, strtotime, escape, format, merge, nl2br, number_format, replace, reverse, round, striptags, title, url_encode } from \\"melody-runtime\\";
+export const _template = {};
+
+_template.render = function (_context) {
+    let myData, myArray;
+    myData = {
+        \\"test\\": \\"value\\",
+        \\"meaningOfLife\\": 42,
+        \\"True\\": false
+    };
+    myArray = [\\"This\\", \\"is\\", \\"an\\", \\"array\\"];
+    return <ul className=\\"filters\\"><li>{Math.abs(1.5)}</li><li>{batch(myArray, 2, \\"batch\\")}</li><li>{capitalize(\\"capitalise\\")}</li><li><span dangerouslySetInnerHTML={{
+                __html: \\"Test String\\"
+            }} /></li><li>{temp(strtotime(\\"+1 day\\", \\"2018-03-01\\"))(\\"Y-m-d\\")}</li><li>{_context.elephant != null && _context.elephant !== '' ? _context.elephant : \\"elephant\\"}</li><li>{escape(\\"<div>HTML</div>\\")}</li><li>{first(myArray)}</li><li>{format(\\"I like %s, it is %s\\", \\"Twig\\", \\"nice\\")}</li><li>{[1, 2, 3].join(\\"|\\")}</li><li><span dangerouslySetInnerHTML={{
+                __html: JSON.stringify(myData)
+            }} /></li><li>{keys(myData)}</li><li>{last(myArray)}</li><li>{myArray.length}</li><li>{\\"Lower\\".toLowerCase()}</li><li>{merge(myArray, [\\"Yes\\"]).length}</li><li><span dangerouslySetInnerHTML={{
+                __html: nl2br(\\"nThis is a new line\\\\\\\\nAnd this\\")
+            }} /></li><li>{number_format(9800.333, 2, \\".\\", \\",\\")}</li><li>{replace(\\"I like fish\\", {
+                \\"fish\\": \\"meat\\"
+            })}</li><li>{reverse(myArray)}</li><li>{round(42.55)}</li><li>{\\"12345\\".slice(1, 3)}</li><li>{myArray.sort()}</li><li>{\\"one, two, three, four, five\\".split(\\",\\", 3)}</li><li>{striptags(\\"<div>HTML</div>\\")}</li><li>{title(\\"Huzzah for twig!\\")}</li><li>{\\"  I like Twig.  \\".trim()}</li><li>{\\"Upper\\".toUpperCase()}</li><li>{url_encode(\\"path-seg*ment\\")}</li></ul>;
+};
+
+if (process.env.NODE_ENV !== \\"production\\") {
+    _template.displayName = \\"Filters\\";
+}
+
+export default function Filters(props) {
+    return _template.render(props);
+}
+"
+`;
+
 exports[`Compiler should correctly transform for if else.template 1`] = `
 "
 import { isEmpty } from \\"melody-runtime\\";


### PR DESCRIPTION
- Fixed two typos where `repalceWithJS` should have been `replaceWithJS`
- Added `filters.template` file to test all Twig filters
- Updated snapshot