### PR TITLE
 #36 chore/fix filter tests

### DIFF
--- a/packages/melody-runtime/__tests__/FilterSpec.js
+++ b/packages/melody-runtime/__tests__/FilterSpec.js
@@ -360,7 +360,7 @@ describe('Twig filter runtime', function() {
             expect(format("%%+d = '%+d'", u)).to.equal("%+d = '-43951789'");
 
             expect(() => format("%%f = '%*.*f'", 1, n)).to.throw(
-                'toFixed() digits argument must be between 0 and 20'
+                /toFixed\(\) digits argument must be between 0 and (20|100)/
             );
         });
 


### PR DESCRIPTION
Precision range has been changed to 0-100 in v8 starting from the node 8.10.0+
Our filter tests were failing because of that on node 8. This commit
fixes broken tests