### PR TITLE
fix(build): generates esm modules using rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "redux-promise": "^0.5.3",
         "redux-thunk": "^2.2.0",
         "rimraf": "^2.6.1",
-        "rollup": "^0.41.4",
+        "rollup": "^0.63.5",
         "rollup-plugin-babel": "^2.7.1",
         "rollup-plugin-json": "^2.1.0",
         "rollup-plugin-uglify": "^2.0.1",

--- a/packages/melody-code-frame/package.json
+++ b/packages/melody-code-frame/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-compiler/package.json
+++ b/packages/melody-compiler/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-component/package.json
+++ b/packages/melody-component/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js",
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js",
     "coverage": "nyc npm run test"
   },
   "author": "",

--- a/packages/melody-devtools/package.json
+++ b/packages/melody-devtools/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js",
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js",
     "coverage": "nyc npm run test"
   },
   "author": "",

--- a/packages/melody-extension-core/package.json
+++ b/packages/melody-extension-core/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-hoc/package.json
+++ b/packages/melody-hoc/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-idom/package.json
+++ b/packages/melody-idom/package.json
@@ -3,11 +3,11 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./built/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "types": "./built/index.d.ts",
   "scripts": {
     "prebuild": "tsc",
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i built/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i built/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-jest-transform/package.json
+++ b/packages/melody-jest-transform/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "./lib/index.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-loader/package.json
+++ b/packages/melody-loader/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-parser/package.json
+++ b/packages/melody-parser/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-parser/src/Lexer.js
+++ b/packages/melody-parser/src/Lexer.js
@@ -560,9 +560,8 @@ export default class Lexer {
 
     matchText(pos) {
         let input = this.input,
-            exit = false,
             c;
-        while (!exit && ((c = input.la(0)) && c !== EOF)) {
+        while ((c = input.la(0)) && c !== EOF) {
             if (c === '{') {
                 const c2 = input.la(1);
                 if (c2 === '{' || c2 === '#' || c2 === '%') {

--- a/packages/melody-plugin-idom/package.json
+++ b/packages/melody-plugin-idom/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-plugin-jsx/package.json
+++ b/packages/melody-plugin-jsx/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-plugin-load-functions/package.json
+++ b/packages/melody-plugin-load-functions/package.json
@@ -3,9 +3,9 @@
     "version": "1.1.0",
     "description": "",
     "main": "./lib/index.js",
-    "jsnext:main": "./src/index.js",
+    "jsnext:main": "./lib/index.esm.js",
     "scripts": {
-        "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+        "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js"
     },
     "author": "",
     "license": "Apache-2.0",

--- a/packages/melody-plugin-skip-if/package.json
+++ b/packages/melody-plugin-skip-if/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; SUPPORT_CJS=true rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-redux/package.json
+++ b/packages/melody-redux/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-runtime/package.json
+++ b/packages/melody-runtime/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-traverse/package.json
+++ b/packages/melody-traverse/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-types/package.json
+++ b/packages/melody-types/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/melody-util/package.json
+++ b/packages/melody-util/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./lib/index.esm.js",
   "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js -o lib/index.js"
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,47 @@
+import fs from 'fs';
+import path from 'path';
 import babel from 'rollup-plugin-babel';
 import json from 'rollup-plugin-json';
 import uglify from 'rollup-plugin-uglify';
 
-var plugins = [json(), babel()];
+// reads package.json of packages (melody-*) in packages directory
+const pkg = fs.readFileSync(path.join(process.cwd(), './package.json'));
+const pkgJSON = JSON.parse(pkg);
+
+/**
+ *  Default rollup config
+ */
+const config = {
+    output: [
+        {
+            file: path.resolve(process.cwd(), pkgJSON.main),
+            format: 'cjs',
+        },
+    ],
+    plugins: [json(), babel()],
+    external: [
+        ...Object.keys(pkgJSON.dependencies || {}),
+        ...Object.keys(pkgJSON.peerDependencies || {}),
+    ],
+};
+
+/**
+ * ES module output configuration
+ */
+const esmModuleOutput = function() {
+    return {
+        file: path.resolve(process.cwd(), pkgJSON['jsnext:main']),
+        format: 'es',
+    };
+};
+
+// Let's skip ES Modules in production environment
+if (pkgJSON['jsnext:main'] && process.env.NODE_ENV !== 'production') {
+    config.output.push(esmModuleOutput());
+}
 
 if (process.env.NODE_ENV === 'production') {
-    plugins.push(
+    config.plugins.push(
         uglify({
             mangle: {
                 toplevel: true,
@@ -14,7 +50,4 @@ if (process.env.NODE_ENV === 'production') {
     );
 }
 
-export default {
-    format: 'cjs',
-    plugins: plugins,
-};
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
 "@types/jest@^22.0.1":
   version "22.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.0.1.tgz#6370a6d60cce3845e4cd5d00bf65f654264685bc"
@@ -5020,11 +5024,12 @@ rollup-pluginutils@^2.0.1:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
 
-rollup@^0.41.4:
-  version "0.41.6"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
+rollup@^0.63.5:
+  version "0.63.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.63.5.tgz#5543eecac9a1b83b7e1be598b5be84c9c0a089db"
   dependencies:
-    source-map-support "^0.4.0"
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
 run-async@^0.1.0:
   version "0.1.0"
@@ -5188,7 +5193,7 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-map-support@^0.4.0, source-map-support@^0.4.15:
+source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:


### PR DESCRIPTION
**Type**: Build

**Problem**:
While using `jsnext:main` with webpack's [resolve mainFiels](https://webpack.js.org/configuration/resolve/#resolve-mainfields) in melody applications, we have following problems:
- **Whole lodash in bundle** : We are using `babel-plugin-lodash` to treeshake lodash functions, but jsnext:main field points to ES6 code which is requiring whole lodash. eg. `import {find} from 'lodash'` and it does not use any `babel-plugin-lodash` because we are not transpiling it using babel. <img width="1440" alt="screen shot 2018-07-25 at 11 44 49" src="https://user-images.githubusercontent.com/6918450/43193478-68ecfd50-9000-11e8-9b91-1e51e04244ac.png">
- **Unexpected Token**: It generates error for `type` as we are not transpiling it. <img width="719" alt="screen shot 2018-07-25 at 11 43 00" src="https://user-images.githubusercontent.com/6918450/43193516-83402fb0-9000-11e8-8835-cfac8b8c4954.png">

**Changes in the PR**:
- Generates sepates ES modules with treeshaked lodash for every package. <img width="1439" alt="screen shot 2018-07-25 at 12 03 41" src="https://user-images.githubusercontent.com/6918450/43194542-e643e172-9002-11e8-86f1-12f5ab8e9097.png">

- Define external dependencies in the bundle. 
- Upgrades rollup to latest version `v0.63.4` as it support `output` key. 
- Removes `SUPPORT_CJS=true` as transpilation in `cjs`.

Please review and let me know, if anything is incorrect. 

Thanks 😀 