### PR TITLE
chore: updates test debug command

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "test-ci": "TZ=Europe/London jest --coverage --runInBand --no-cache && cat ./coverage/lcov.info | coveralls",
         "test-travis": "TZ=Europe/London jest --maxWorkers=4",
         "test-accept": "cross-env NODE_ENV=mocha lerna run test-accept",
-        "test-debug": "node --inspect --debug-brk ./node_modules/jest-cli/bin/jest.js -i"
+        "test-debug": "TZ=Europe/London node --inspect-brk ./node_modules/jest/bin/jest.js -i"
     },
     "devDependencies": {
         "@types/jest": "^22.0.1",


### PR DESCRIPTION
**Type**: chore

I was debugging some tests and found a deprecation warning as 
```
internal/process/warning.js:18 (node:81929) [DEP0062] DeprecationWarning: `node --inspect --debug-brk` is deprecated. Please use `node --inspect-brk` instead.
```

Opening a small PR 😃 .