### PR TITLE
chore: adds .npmignore for melody packages

### DIFF
--- a/packages/melody-code-frame/.npmignore
+++ b/packages/melody-code-frame/.npmignore
@@ -1,2 +1,2 @@
 **/__tests__/**
-src
+yarn.lock

--- a/packages/melody-compiler/.npmignore
+++ b/packages/melody-compiler/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-component/.npmignore
+++ b/packages/melody-component/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-devtools/.npmignore
+++ b/packages/melody-devtools/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-extension-core/.npmignore
+++ b/packages/melody-extension-core/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-hoc/.npmignore
+++ b/packages/melody-hoc/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-idom/.npmignore
+++ b/packages/melody-idom/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-jest-transform/.npmignore
+++ b/packages/melody-jest-transform/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-loader/.npmignore
+++ b/packages/melody-loader/.npmignore
@@ -1,0 +1,3 @@
+**/__tests__/**
+**/__fixtures__/**
+yarn.lock

--- a/packages/melody-parser/.npmignore
+++ b/packages/melody-parser/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-plugin-idom/.npmignore
+++ b/packages/melody-plugin-idom/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-plugin-jsx/.npmignore
+++ b/packages/melody-plugin-jsx/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-plugin-load-functions/.npmignore
+++ b/packages/melody-plugin-load-functions/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-plugin-skip-if/.npmignore
+++ b/packages/melody-plugin-skip-if/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-redux/.npmignore
+++ b/packages/melody-redux/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-runtime/.npmignore
+++ b/packages/melody-runtime/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-traverse/.npmignore
+++ b/packages/melody-traverse/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-types/.npmignore
+++ b/packages/melody-types/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/melody-util/.npmignore
+++ b/packages/melody-util/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock

--- a/packages/neutrino-preset-melody/.npmignore
+++ b/packages/neutrino-preset-melody/.npmignore
@@ -1,0 +1,2 @@
+**/__tests__/**
+yarn.lock


### PR DESCRIPTION
#### Reference issue: N/A

#### What changed in this PR:

Adds `.npmignore` for every `melody-package`

