### PR TITLE
Prevent error when current stack element is null

### DIFF
--- a/packages/melody-idom/src/node_data.ts
+++ b/packages/melody-idom/src/node_data.ts
@@ -135,7 +135,7 @@ const importNode = function(node) {
     const stack = [node];
     while (stack.length) {
         const node = stack.pop();
-        if (node['__incrementalDOMData']) {
+        if (!node || node['__incrementalDOMData']) {
             continue;
         }
         const isElement = node instanceof Element;


### PR DESCRIPTION
#### What changed in this PR:

When looking at live error reports, we can see an occasional error where we are accessing `incrementalDOMData` on a `null` value.

According to the stack trace, the modified use is responsible for that. Considering how the code works, that seems rather impossible (there's no code running that'd change the DOM while we're importing nodes) but this should be the easiest fix for it.