### PR TITLE
Fix getFocusedPath can break on IE11 for svg elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - incorrect 'is' method call in melody-types [#20](https://github.com/trivago/melody/issues/20)
+- getFocusedPath can break on IE11 for svg elements [#57](https://github.com/trivago/melody/issues/57)
 
 ### Chore & Maintenance
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         },
         {
             "path": "./packages/melody-idom/lib/index.js",
-            "maxSize": "4.65 kB"
+            "maxSize": "4.66 kB"
         },
         {
             "path": "./packages/melody-hoc/lib/index.js",

--- a/packages/melody-idom/__tests__/PatchInnerSpec.ts
+++ b/packages/melody-idom/__tests__/PatchInnerSpec.ts
@@ -98,19 +98,15 @@ describe("patching an element's children", () => {
                 expect(node).to.equal(div);
             });
 
-            describe('when Node.prototype.contains is not available', () => {
-                beforeEach(() => {
-                    container.contains = undefined;
+            it('from elementOpen when Node.prototype.contains not available', () => {
+                container.contains = undefined;
+
+                patchInner(container, () => {
+                    node = elementOpen('div');
+                    elementClose('div');
                 });
 
-                it('should return node from elementOpen', () => {
-                    patchInner(container, () => {
-                        node = elementOpen('div');
-                        elementClose('div');
-                    });
-
-                    expect(node).to.equal(div);
-                });
+                expect(node).to.equal(div);
             });
         });
     });

--- a/packages/melody-idom/__tests__/PatchInnerSpec.ts
+++ b/packages/melody-idom/__tests__/PatchInnerSpec.ts
@@ -97,6 +97,21 @@ describe("patching an element's children", () => {
 
                 expect(node).to.equal(div);
             });
+
+            describe('when Node.prototype.contains is not available', () => {
+                beforeEach(() => {
+                    container.contains = undefined;
+                });
+
+                it('should return node from elementOpen', () => {
+                    patchInner(container, () => {
+                        node = elementOpen('div');
+                        elementClose('div');
+                    });
+
+                    expect(node).to.equal(div);
+                });
+            });
         });
     });
 
@@ -169,7 +184,7 @@ describe('when patching an non existing element', function() {
         expect(() =>
             patchInner(null, function() {
                 expect(false).to.be.true;
-            }),
+            })
         ).to.throw('Patch invoked without an element');
     });
 });

--- a/packages/melody-idom/src/dom_util.ts
+++ b/packages/melody-idom/src/dom_util.ts
@@ -77,18 +77,16 @@ const getActiveElement = function(node) {
  * @param {?Element} elm The element that should be child of elm.
  * @return {Boolean} whether or not elm is contained within node.
  */
-const nodeContainsElm = function(node, elm) {
+const nodeContainsElement = function(node, elm) {
     if (node.contains) {
         return node.contains(elm);
     }
 
-    do {
-        if (elm === node) {
-            return true;
-        }
-    } while ((elm = elm && elm.parentNode));
+    while (elm && elm !== node) {
+        elm = elm.parentNode;
+    }
 
-    return false;
+    return elm === node;
 };
 
 /**
@@ -101,7 +99,7 @@ const nodeContainsElm = function(node, elm) {
 const getFocusedPath = function(node, root) {
     const activeElement = getActiveElement(node);
 
-    if (!activeElement || !nodeContainsElm(node, activeElement)) {
+    if (!activeElement || !nodeContainsElement(node, activeElement)) {
         return [];
     }
 

--- a/packages/melody-idom/src/dom_util.ts
+++ b/packages/melody-idom/src/dom_util.ts
@@ -70,6 +70,28 @@ const getActiveElement = function(node) {
 };
 
 /**
+ * Function that checks whether some element is contained inside a node. This function
+ * has a fallback implementation for cases where Node.prototype.contains is
+ * not implemented (e.g. IE11 for SVGElements).
+ * @param {!Node} node The node that should be parent of elm.
+ * @param {?Element} elm The element that should be child of elm.
+ * @return {Boolean} whether or not elm is contained within node.
+ */
+const nodeContainsElm = function(node, elm) {
+    if (node.contains) {
+        return node.contains(elm);
+    }
+
+    do {
+        if (elm === node) {
+            return true;
+        }
+    } while ((elm = elm && elm.parentNode));
+
+    return false;
+};
+
+/**
  * Gets the path of nodes that contain the focused node in the same document as
  * a reference node, up until the root.
  * @param {!Node} node The reference node to get the activeElement for.
@@ -79,7 +101,7 @@ const getActiveElement = function(node) {
 const getFocusedPath = function(node, root) {
     const activeElement = getActiveElement(node);
 
-    if (!activeElement || !node.contains(activeElement)) {
+    if (!activeElement || !nodeContainsElm(node, activeElement)) {
         return [];
     }
 


### PR DESCRIPTION
#### Reference issue: https://github.com/trivago/melody/issues/57

#### What changed in this PR:
* Add simple fallback behavior to `node.contains`.

In `melody-idom/src/dom_util.ts` a call to `node.contains` was wrapped in a function that contains a fallback implementation for cases where `Node.prototype.contains` is not defined. This was causing the breaking behavior in the method `getFocusedPath` mentioned in the issue.