### PR TITLE
Update bundlesize version and cleanup of warnings during installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ jobs:
         - stage: npm release
           node_js: "8"
           script: yarn release-travis
+env:
+    global:
+        secure: M0LOw84M51PwFgLnOIpHZLXVIYjW21tNkohWRM22n/25Ajg2bV8ZkaBgo/wdLfHENB1LbsQScJPSBy2oy6hL1xOVKithxEB1pGR6/xcQc6f5XmEOFf645O7Kr+vsY0Zuz6ROAmii5dZegZbkNizagpqAPAPCUk9eWn1gNL6prWIE24IYsNQdvZUNzhmd9mEz52IJA9D8Nd4e4Bd6TurBP/DweAf/mpIkyyAKcqZ80PeQNBgiqMjremBShp57AxZkmt/pWFuDfYLK9uwQXnALWYbPO9PHejRW/0zNKId0yTaOaduzm/x46E+e6knhRt1oi7Tf+Uqy+hwNHJtZM2ueOEmMPDTIryLySFsqcyxCL4toDdxnGrkaR21Se0+8rEgj25mxndaUayXcuRImW3fhSvfusjTbrPAo/4Ux8Fdukafs6x0tr2cvo8PLZCjeLx6UexlZ2OFQK6TphUOr9GcsXZxr8ySuKADvZR2wNnfux+dezaz3m6yYkxXjuIrS3dhV0dee8S+El7IBskagOJnwHiuy948n25IO/vKy65Jsh04r7wJCZri1eIcpER9TMPfw0wNeHmgJh0MwfB+3kZ2uWaw+vqWojEavlmeo9FQvUNbTpvqWeocAjZOH9BY3N0lG23YSccU1QNTFztluFqIKcDXxDPyj58/WZm5DwTWKrV8=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Migration to `babel-preset-env`. [#50](https://github.com/trivago/melody/issues/50)
 - Drops node 7 support `babel-preset-env`. [#55](https://github.com/trivago/melody/issues/55)
 - Adds node 10 support `babel-preset-env`. [#55](https://github.com/trivago/melody/issues/55)
+- Updates `bundlesize` dependency to `^0.15.2`, the latest release
+- Removes warnings during installation thrown by `lerna` and `npm`
 
 ## 1.1.0
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "engines": {
         "node": ">=6.0.0"
     },
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trivago/melody.git"
+    },
     "scripts": {
         "bootstrap": "npm run lerna bootstrap",
         "build": "lerna run build",
@@ -19,7 +23,7 @@
         "flow": "flow; test $? -eq 0 -o $? -eq 2",
         "lerna": "lerna",
         "lint": "eslint ./packages/*/src",
-        "prepublish": "npm run bootstrap && npm run build:release",
+        "prepare": "npm run bootstrap && npm run build:release",
         "pretest": "./bin/pretest.sh",
         "posttest": "./bin/posttest.sh",
         "prettier": "prettier --write \"./packages/melody-*/src/**/*.[tj]s\"",
@@ -50,7 +54,7 @@
         "babel-preset-env": "^1.7.0",
         "babel-preset-react": "^6.23.0",
         "babel-register": "^6.23.0",
-        "bundlesize": "^0.13.2",
+        "bundlesize": "^0.15.2",
         "chai": "^3.0.0",
         "chai-subset": "^1.5.0",
         "commitizen": "^2.9.6",


### PR DESCRIPTION
#### Reference issue: [#ISSUEID](https://github.com/trivago/melody/issues/000)
N/A

#### What changed in this PR:

Updates `bundlesize` dependency
Removes warnings during normal installation

