### PR TITLE
Add implementation for filter 'trim' to be compatible with Twig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Features
+
+- Filter `trim`: add support for advanced features [#64](https://github.com/trivago/melody/pull/64)
+
 ### Fixes
 
 - incorrect 'is' method call in melody-types [#20](https://github.com/trivago/melody/issues/20)

--- a/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -213,7 +213,7 @@ export default function EmbedNested(props) {
 
 exports[`Compiler should correctly transform expressions.template 1`] = `
 "
-import { isEmpty } from \\"melody-runtime\\";
+import { isEmpty, trim } from \\"melody-runtime\\";
 import { includes, startsWith, endsWith, range } from \\"lodash\\";
 import { text, raw } from \\"melody-idom\\";
 export const _template = {};
@@ -269,9 +269,9 @@ _template.render = function (_context) {
   text(range(2, 3 + 1, 2).sort().join(\\",\\"));
   raw(_context.test);
   text(Math.abs(2.4));
-  text(JSON.stringify({
+  text(trim(JSON.stringify({
     a: \\"b\\"
-  }).trim());
+  })));
   text([2, 3].length);
   text(\\"test.foo\\".split(\\".\\"));
 };

--- a/packages/melody-extension-core/src/index.js
+++ b/packages/melody-extension-core/src/index.js
@@ -54,6 +54,7 @@ const filterMap = [
     'striptags',
     'title',
     'url_encode',
+    'trim',
 ].reduce((map, filterName) => {
     map[filterName] = 'melody-runtime';
     return map;

--- a/packages/melody-extension-core/src/visitors/filters.js
+++ b/packages/melody-extension-core/src/visitors/filters.js
@@ -115,14 +115,6 @@ export default {
             )
         );
     },
-    trim(path) {
-        path.replaceWithJS(
-            t.callExpression(
-                t.memberExpression(path.node.target, t.identifier('trim')),
-                path.node.arguments
-            )
-        );
-    },
     convert_encoding(path) {
         // encoding conversion is not supported
         path.replaceWith(path.node.target);

--- a/packages/melody-plugin-jsx/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-plugin-jsx/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -156,7 +156,7 @@ exports[`Compiler should correctly transform filters.template 1`] = `
 "
 import temp from \\"moment\\";
 import { capitalize, first, keys, last } from \\"lodash\\";
-import { batch, strtotime, escape, format, merge, nl2br, number_format, replace, reverse, round, striptags, title, url_encode } from \\"melody-runtime\\";
+import { batch, strtotime, escape, format, merge, nl2br, number_format, replace, reverse, round, striptags, title, trim, url_encode } from \\"melody-runtime\\";
 export const _template = {};
 
 _template.render = function (_context) {
@@ -175,7 +175,7 @@ _template.render = function (_context) {
                 __html: nl2br(\\"nThis is a new line\\\\\\\\nAnd this\\")
             }} /></li><li>{number_format(9800.333, 2, \\".\\", \\",\\")}</li><li>{replace(\\"I like fish\\", {
                 \\"fish\\": \\"meat\\"
-            })}</li><li>{reverse(myArray)}</li><li>{round(42.55)}</li><li>{\\"12345\\".slice(1, 3)}</li><li>{myArray.sort()}</li><li>{\\"one, two, three, four, five\\".split(\\",\\", 3)}</li><li>{striptags(\\"<div>HTML</div>\\")}</li><li>{title(\\"Huzzah for twig!\\")}</li><li>{\\"  I like Twig.  \\".trim()}</li><li>{\\"Upper\\".toUpperCase()}</li><li>{url_encode(\\"path-seg*ment\\")}</li></ul>;
+            })}</li><li>{reverse(myArray)}</li><li>{round(42.55)}</li><li>{\\"12345\\".slice(1, 3)}</li><li>{myArray.sort()}</li><li>{\\"one, two, three, four, five\\".split(\\",\\", 3)}</li><li>{striptags(\\"<div>HTML</div>\\")}</li><li>{title(\\"Huzzah for twig!\\")}</li><li>{trim(\\"  I like Twig.  \\")}</li><li>{\\"Upper\\".toUpperCase()}</li><li>{url_encode(\\"path-seg*ment\\")}</li></ul>;
 };
 
 if (process.env.NODE_ENV !== \\"production\\") {

--- a/packages/melody-runtime/__tests__/FilterSpec.js
+++ b/packages/melody-runtime/__tests__/FilterSpec.js
@@ -30,6 +30,7 @@ import {
     number_format,
     format,
     strtotime,
+    trim,
 } from '../src';
 
 describe('Twig filter runtime', function() {
@@ -461,6 +462,49 @@ describe('Twig filter runtime', function() {
             expect(strtotime('1801/09/10', now)).to.equal(false);
             expect(strtotime('1979-13-10', now)).to.equal(false);
             expect(strtotime('1979/13/10', now)).to.equal(false);
+        });
+    });
+
+    describe('trim filter', function() {
+        it('should fallback to native trim', function() {
+            expect(trim('  melody  ')).to.equal('melody');
+        });
+
+        it('should correctly trim one character', function() {
+            expect(trim('--melody--', '-', 'left')).to.equal('melody--');
+            expect(trim('--melody--', '-', 'right')).to.equal('--melody');
+            expect(trim('--melody--', '-', 'both')).to.equal('melody');
+            expect(trim('--mel--ody--', '-', 'both')).to.equal('mel--ody');
+        });
+
+        it('should correctly trim multiple characters', function() {
+            expect(trim('(()melody())', '()', 'left')).to.equal('melody())');
+            expect(trim('(()melody())', '()', 'right')).to.equal('(()melody');
+            expect(trim('(()melody())', '()', 'both')).to.equal('melody');
+            expect(trim('(()me(l)ody())', '()', 'both')).to.equal('me(l)ody');
+        });
+
+        it('should not change the source string if not needed', function() {
+            expect(trim('(()melody())', '-my', 'both')).to.equal(
+                '(()melody())'
+            );
+        });
+
+        it('should work with empty strings', function() {
+            expect(trim('', '-', 'both')).to.equal('');
+            expect(trim('', '-', 'left')).to.equal('');
+            expect(trim('', '-', 'right')).to.equal('');
+            expect(trim('  melody  ', '', 'both')).to.equal('  melody  ');
+        });
+
+        it('should return an empty string if every character is removed', function() {
+            expect(trim('----', '-', 'both')).to.equal('');
+            expect(trim('----', '-', 'left')).to.equal('');
+            expect(trim('----', '-', 'right')).to.equal('');
+        });
+
+        it('should error if side is not valid', function() {
+            expect(() => trim('----', '-', 'foobar')).to.throw();
         });
     });
 });

--- a/packages/melody-runtime/src/filters.js
+++ b/packages/melody-runtime/src/filters.js
@@ -961,3 +961,79 @@ export function strtotime(input, now) {
 
     return date.getTime() / 1000;
 }
+
+export function trim(str, charlist, side = 'both') {
+    //  discuss at: http://phpjs.org/functions/trim/
+    // original by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+    // improved by: mdsjack (http://www.mdsjack.bo.it)
+    // improved by: Alexander Ermolaev (http://snippets.dzone.com/user/AlexanderErmolaev)
+    // improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+    // improved by: Steven Levithan (http://blog.stevenlevithan.com)
+    // improved by: Jack
+    //    input by: Erkekjetter
+    //    input by: DxGx
+    // bugfixed by: Onno Marsman
+    //   example 1: trim('    Kevin van Zonneveld    ');
+    //   returns 1: 'Kevin van Zonneveld'
+    //   example 2: trim('Hello World', 'Hdle');
+    //   returns 2: 'o Wor'
+    //   example 3: trim(16, 1);
+    //   returns 3: 6
+
+    // Melody improvement: Sergio Santoro
+    //   unify ltrim and rtrim as per Twig docs
+
+    if (side !== 'both' && side !== 'left' && side !== 'right') {
+        throw new Error(
+            'Filter "trim". Invalid value ' +
+                side +
+                ' for parameter "side". Valid values are "both", "left", "right".'
+        );
+    }
+
+    var whitespace,
+        l = 0,
+        i = 0;
+    str += '';
+
+    if (!charlist) {
+        // default list
+        whitespace =
+            ' \n\r\t\f\x0b\xa0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u2028\u2029\u3000';
+    } else {
+        // preg_quote custom list
+        charlist += '';
+        whitespace = charlist.replace(
+            /([\[\]\(\)\.\?\/\*\{\}\+\$\^\:])/g,
+            '$1'
+        );
+    }
+
+    if (side === 'both' || side === 'left') {
+        l = str.length;
+        for (i = 0; i < l; i++) {
+            if (whitespace.indexOf(str.charAt(i)) === -1) {
+                str = str.substring(i);
+                break;
+            }
+        }
+        if (i === l) {
+            return '';
+        }
+    }
+
+    if (side === 'both' || side === 'right') {
+        l = str.length;
+        for (i = l - 1; i >= 0; i--) {
+            if (whitespace.indexOf(str.charAt(i)) === -1) {
+                str = str.substring(0, i + 1);
+                break;
+            }
+        }
+        if (i === -1) {
+            return '';
+        }
+    }
+
+    return str;
+}

--- a/packages/melody-runtime/src/filters.js
+++ b/packages/melody-runtime/src/filters.js
@@ -962,26 +962,11 @@ export function strtotime(input, now) {
     return date.getTime() / 1000;
 }
 
-export function trim(str, charlist, side = 'both') {
-    //  discuss at: http://phpjs.org/functions/trim/
-    // original by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
-    // improved by: mdsjack (http://www.mdsjack.bo.it)
-    // improved by: Alexander Ermolaev (http://snippets.dzone.com/user/AlexanderErmolaev)
-    // improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
-    // improved by: Steven Levithan (http://blog.stevenlevithan.com)
-    // improved by: Jack
-    //    input by: Erkekjetter
-    //    input by: DxGx
-    // bugfixed by: Onno Marsman
-    //   example 1: trim('    Kevin van Zonneveld    ');
-    //   returns 1: 'Kevin van Zonneveld'
-    //   example 2: trim('Hello World', 'Hdle');
-    //   returns 2: 'o Wor'
-    //   example 3: trim(16, 1);
-    //   returns 3: 6
-
-    // Melody improvement: Sergio Santoro
-    //   unify ltrim and rtrim as per Twig docs
+export function trim(str, charList, side = 'both') {
+    if (charList === undefined && side === 'both') {
+        // Use String.prototype.trim() for efficiency
+        return String(str).trim();
+    }
 
     if (side !== 'both' && side !== 'left' && side !== 'right') {
         throw new Error(
@@ -991,49 +976,21 @@ export function trim(str, charlist, side = 'both') {
         );
     }
 
-    var whitespace,
-        l = 0,
-        i = 0;
-    str += '';
+    const strLen = str.length;
 
-    if (!charlist) {
-        // default list
-        whitespace =
-            ' \n\r\t\f\x0b\xa0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u2028\u2029\u3000';
-    } else {
-        // preg_quote custom list
-        charlist += '';
-        whitespace = charlist.replace(
-            /([\[\]\(\)\.\?\/\*\{\}\+\$\^\:])/g,
-            '$1'
-        );
-    }
-
+    let trimStart = 0;
     if (side === 'both' || side === 'left') {
-        l = str.length;
-        for (i = 0; i < l; i++) {
-            if (whitespace.indexOf(str.charAt(i)) === -1) {
-                str = str.substring(i);
-                break;
-            }
-        }
-        if (i === l) {
-            return '';
+        while (trimStart < strLen && charList.indexOf(str[trimStart]) !== -1) {
+            trimStart++;
         }
     }
 
+    let trimEnd = strLen;
     if (side === 'both' || side === 'right') {
-        l = str.length;
-        for (i = l - 1; i >= 0; i--) {
-            if (whitespace.indexOf(str.charAt(i)) === -1) {
-                str = str.substring(0, i + 1);
-                break;
-            }
-        }
-        if (i === -1) {
-            return '';
+        while (trimEnd > 0 && charList.indexOf(str[trimEnd - 1]) !== -1) {
+            trimEnd--;
         }
     }
 
-    return str;
+    return str.substr(trimStart, trimEnd - trimStart);
 }

--- a/packages/melody-runtime/src/index.js
+++ b/packages/melody-runtime/src/index.js
@@ -29,6 +29,7 @@ export {
     title,
     url_encode,
     strtotime,
+    trim,
 } from './filters';
 export { random, min, max, cycle, attribute } from './functions';
 export { isEmpty, inheritBlocks } from './helpers';


### PR DESCRIPTION
We cannot use the native `String.prototype.trim` because Twig supports additional parameters and features.
Please refer to the official Twig docs: https://twig.symfony.com/doc/2.x/filters/trim.html