### PR TITLE
Feature - throw an error in melody-redux's connect if no store found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Filter `trim`: add support for advanced features [#64](https://github.com/trivago/melody/pull/64)
+- Throw an error in melody-redux's connect if no store found [#68](https://github.com/trivago/melody/pull/68)
 
 ### Fixes
 

--- a/packages/melody-redux/src/index.js
+++ b/packages/melody-redux/src/index.js
@@ -35,7 +35,7 @@ const findNextStore = comp => {
         }
     }
     if (process.env.NODE_ENV !== 'production') {
-        console.error('Could not find store. Did you forget to provide a store?');
+        throw new Error('Could not find store. Did you forget to provide a store?');
     }
     return null;
 };

--- a/packages/melody-redux/src/index.js
+++ b/packages/melody-redux/src/index.js
@@ -34,6 +34,9 @@ const findNextStore = comp => {
             return node.store;
         }
     }
+    if (process.env.NODE_ENV !== 'production') {
+        console.error('Could not find store. Did you forget to provide a store?');
+    }
     return null;
 };
 


### PR DESCRIPTION
This PR adds an error message that will be thrown when no store is found within findNextStore function.
Currently, the findNextStore function returns null without an error, this causes js errors like Cannot read property 'subscribe' of null or Cannot read property 'getState' of null; this error will provide better context on why the error is being thrown.

P.S. This PR ensues discussions here: https://github.com/trivago/melody/pull/33