### PR TITLE
Bugfix: Unsubscribe from Redux store when component is unmounted

### DIFF
--- a/packages/melody-redux/src/WrapperComponent.js
+++ b/packages/melody-redux/src/WrapperComponent.js
@@ -20,7 +20,16 @@ const createWrapperComponent = Component =>
         constructor() {
             this.refs = Object.create(null);
             this.props = null;
-            this.childInstance = new Component();
+
+            const wrappedInstance = this;
+            class EnhancedComponent extends Component {
+                componentWillUnmount() {
+                    Component.prototype.componentWillUnmount.call(this);
+                    wrappedInstance.componentWillUnmount();
+                }
+            }
+
+            this.childInstance = new EnhancedComponent();
             link(this, this.childInstance);
         }
 
@@ -32,6 +41,8 @@ const createWrapperComponent = Component =>
         get el() {
             return this.childInstance.el;
         }
+
+        componentWillUnmount() {}
     };
 
 export { createWrapperComponent };


### PR DESCRIPTION
`connect` was not correctly unsubscribing from the Redux store when `componentWillUnmount` was triggered in the `childInstance`.

I'm now forwarding the event `componentWillUnmount` to the `WrapperComponent` so that the cleanup is performed as expected.