### PR TITLE
Fix Inconsistencies in the way how `inputs` are handled

### DIFF
--- a/packages/melody-hooks/__tests__/UseCallbackSpec.js
+++ b/packages/melody-hooks/__tests__/UseCallbackSpec.js
@@ -29,48 +29,71 @@ const template = {
 };
 
 describe('useCallback', () => {
-    it('should return a memoized callback', () => {
-        const root = document.createElement('div');
-        const callbacks = [];
-        let setter;
-        const MyComponent = createComponent(() => {
-            const [value, setValue] = useState(false);
-            setter = setValue;
-            const callback = useCallback(() => {});
-            callbacks.push(callback);
-            return { value };
-        }, template);
-        render(root, MyComponent);
-        setter(true);
-        flush();
-        setter(false);
-        flush();
-        assert.equal(
-            callbacks[0] === callbacks[1] && callbacks[1] === callbacks[2],
-            true
-        );
+    describe('without inputs being specified', () => {
+        it('should return the passed callback on every update', () => {
+            const root = document.createElement('div');
+            const callbacks = [];
+            let setter;
+            const MyComponent = createComponent(() => {
+                const [value, setValue] = useState(false);
+                setter = setValue;
+                const callback = useCallback(() => {});
+                callbacks.push(callback);
+                return { value };
+            }, template);
+            render(root, MyComponent);
+            setter(true);
+            flush();
+            setter(false);
+            flush();
+            assert.equal(callbacks[0] !== callbacks[1], true);
+            assert.equal(callbacks[1] !== callbacks[2], true);
+        });
     });
-    it('should return an updated callback when inputs change', () => {
-        const root = document.createElement('div');
-        const callbacks = [];
-        let setter;
-        const MyComponent = createComponent(() => {
-            const [value, setValue] = useState(false);
-            setter = setValue;
-            const callback = useCallback(() => {}, [value]);
-            callbacks.push(callback);
-            return { value };
-        }, template);
-        render(root, MyComponent);
-        setter(true);
-        flush();
-        setter(false);
-        flush();
-        assert.equal(
-            callbacks[0] !== callbacks[1] &&
-                callbacks[1] !== callbacks[2] &&
-                callbacks[2] !== callbacks[0],
-            true
-        );
+    describe('with inputs being specified', () => {
+        it('should return an updated callback when inputs change', () => {
+            const root = document.createElement('div');
+            const callbacks = [];
+            let setter;
+            let setter2;
+            const MyComponent = createComponent(() => {
+                const [value, setValue] = useState(false);
+                const [, setValue2] = useState(false);
+                setter = setValue;
+                setter2 = setValue2;
+                const callback = useCallback(() => {}, [value]);
+                callbacks.push(callback);
+                return { value };
+            }, template);
+            render(root, MyComponent);
+            setter2(true);
+            flush();
+            setter(true);
+            flush();
+            assert.equal(callbacks[0] === callbacks[1], true);
+            assert.equal(callbacks[1] !== callbacks[2], true);
+        });
+        it('should return the same callback when inputs are empty', () => {
+            const root = document.createElement('div');
+            const callbacks = [];
+            let setter;
+            let setter2;
+            const MyComponent = createComponent(() => {
+                const [value, setValue] = useState(false);
+                const [, setValue2] = useState(false);
+                setter = setValue;
+                setter2 = setValue2;
+                const callback = useCallback(() => {}, []);
+                callbacks.push(callback);
+                return { value };
+            }, template);
+            render(root, MyComponent);
+            setter2(true);
+            flush();
+            setter(true);
+            flush();
+            assert.equal(callbacks[0] === callbacks[1], true);
+            assert.equal(callbacks[1] === callbacks[2], true);
+        });
     });
 });

--- a/packages/melody-hooks/__tests__/UseMemoSpec.js
+++ b/packages/melody-hooks/__tests__/UseMemoSpec.js
@@ -29,51 +29,80 @@ const template = {
 };
 
 describe('useMemo', () => {
-    it('should memoize the value', () => {
-        const root = document.createElement('div');
-        const values = [];
-        let setter;
-        const MyComponent = createComponent(() => {
-            const [value, setValue] = useState(false);
-            setter = setValue;
+    describe('without inputs being specified', () => {
+        it('should call the getter on every update', () => {
+            const root = document.createElement('div');
+            const values = [];
+            let setter;
+            const MyComponent = createComponent(() => {
+                const [value, setValue] = useState(false);
+                setter = setValue;
 
-            // always return a new array from getter
-            const memoized = useMemo(() => []);
-            values.push(memoized);
+                // always return a new array from getter
+                const memoized = useMemo(() => []);
+                values.push(memoized);
 
-            return { value };
-        }, template);
-        render(root, MyComponent);
-        setter(true);
-        flush();
-        setter(false);
-        flush();
-        assert.equal(values[0] === values[1] && values[1] === values[2], true);
+                return { value };
+            }, template);
+            render(root, MyComponent);
+            setter(true);
+            flush();
+            setter(false);
+            flush();
+            assert.equal(values[0] !== values[1], true);
+            assert.equal(values[1] !== values[2], true);
+        });
     });
-    it('should update the value when inputs change', () => {
-        const root = document.createElement('div');
-        const values = [];
-        let setter;
-        const MyComponent = createComponent(() => {
-            const [value, setValue] = useState(false);
-            setter = setValue;
+    describe('with inputs being specified', () => {
+        it('should call the getter when inputs change', () => {
+            const root = document.createElement('div');
+            const values = [];
+            let setter;
+            let setter2;
+            const MyComponent = createComponent(() => {
+                const [value, setValue] = useState(false);
+                const [, setValue2] = useState(false);
+                setter = setValue;
+                setter2 = setValue2;
 
-            // always return a new array from getter
-            const memoized = useMemo(() => [], [value]);
-            values.push(memoized);
+                // always return a new array from getter
+                const memoized = useMemo(() => [], [value]);
+                values.push(memoized);
 
-            return { value };
-        }, template);
-        render(root, MyComponent);
-        setter(true);
-        flush();
-        setter(false);
-        flush();
-        assert.equal(
-            values[0] !== values[1] &&
-                values[1] !== values[2] &&
-                values[2] !== values[0],
-            true
-        );
+                return { value };
+            }, template);
+            render(root, MyComponent);
+            setter2(true);
+            flush();
+            setter(true);
+            flush();
+            assert.equal(values[0] === values[1], true);
+            assert.equal(values[1] !== values[2], true);
+        });
+        it('should not call the getter when inputs are empty', () => {
+            const root = document.createElement('div');
+            const values = [];
+            let setter;
+            let setter2;
+            const MyComponent = createComponent(() => {
+                const [value, setValue] = useState(false);
+                const [, setValue2] = useState(false);
+                setter = setValue;
+                setter2 = setValue2;
+
+                // always return a new array from getter
+                const memoized = useMemo(() => [], []);
+                values.push(memoized);
+
+                return { value };
+            }, template);
+            render(root, MyComponent);
+            setter2(true);
+            flush();
+            setter(true);
+            flush();
+            assert.equal(values[0] === values[1], true);
+            assert.equal(values[1] === values[2], true);
+        });
     });
 });

--- a/packages/melody-hooks/src/hooks/useCallback.js
+++ b/packages/melody-hooks/src/hooks/useCallback.js
@@ -22,21 +22,24 @@ export const useCallback = (callback, inputs) => {
     const currentComponent = enterHook(HOOK_TYPE_USE_CALLBACK);
     const { hooksPointer, hooks } = currentComponent;
 
+    const inputsNext =
+        inputs !== undefined && inputs !== null ? inputs : [callback];
+
     if (currentComponent.isCollectingHooks) {
-        hooks.push([HOOK_TYPE_USE_CALLBACK, callback, inputs]);
+        hooks.push([HOOK_TYPE_USE_CALLBACK, callback, inputsNext]);
         return callback;
     }
 
     const hook = hooks[hooksPointer];
     const callbackPrev = hook[1];
     const inputsPrev = hook[2];
-    const dirty =
-        inputs && inputs.length && !shallowEqualsArray(inputsPrev, inputs);
+
+    const dirty = !shallowEqualsArray(inputsPrev, inputsNext);
 
     if (!dirty) return callbackPrev;
 
-    // Update callback
+    // Update callback & inputs
     hook[1] = callback;
-    hook[2] = inputs;
+    hook[2] = inputsNext;
     return callback;
 };

--- a/packages/melody-hooks/src/hooks/useEffect.js
+++ b/packages/melody-hooks/src/hooks/useEffect.js
@@ -25,22 +25,24 @@ const createEffectHook = type => (callback, inputs) => {
     const currentComponent = enterHook(type);
     const { hooksPointer, hooks } = currentComponent;
 
+    const inputsNext =
+        inputs !== undefined && inputs !== null ? inputs : [callback];
+
     if (currentComponent.isCollectingHooks) {
         const dirty = true;
         const unsubscribe = null;
-        hooks.push([type, callback, inputs, dirty, unsubscribe]);
+        hooks.push([type, callback, inputsNext, dirty, unsubscribe]);
         return;
     }
 
     const hook = hooks[hooksPointer];
     const inputsPrev = hook[2];
-    const dirty =
-        !inputs || (inputs.length && !shallowEqualsArray(inputsPrev, inputs));
+    const dirty = !shallowEqualsArray(inputsPrev, inputsNext);
 
     if (dirty) {
         hook[1] = callback;
     }
-    hook[2] = inputs;
+    hook[2] = inputsNext;
     hook[3] = dirty;
 };
 

--- a/packages/melody-hooks/src/hooks/useEffect.js
+++ b/packages/melody-hooks/src/hooks/useEffect.js
@@ -32,15 +32,16 @@ const createEffectHook = type => (callback, inputs) => {
         return;
     }
 
-    const dataPrev = hooks[hooksPointer][2];
+    const hook = hooks[hooksPointer];
+    const inputsPrev = hook[2];
     const dirty =
-        !inputs || (inputs.length && !shallowEqualsArray(dataPrev, inputs));
+        !inputs || (inputs.length && !shallowEqualsArray(inputsPrev, inputs));
 
     if (dirty) {
-        hooks[hooksPointer][1] = callback;
+        hook[1] = callback;
     }
-    hooks[hooksPointer][2] = inputs;
-    hooks[hooksPointer][3] = dirty;
+    hook[2] = inputs;
+    hook[3] = dirty;
 };
 
 export const useEffect = createEffectHook(HOOK_TYPE_USE_EFFECT);

--- a/packages/melody-hooks/src/hooks/useMemo.js
+++ b/packages/melody-hooks/src/hooks/useMemo.js
@@ -22,23 +22,25 @@ export const useMemo = (getter, inputs) => {
     const currentComponent = enterHook(HOOK_TYPE_USE_MEMO);
     const { hooksPointer, hooks } = currentComponent;
 
+    const inputsNext =
+        inputs !== undefined && inputs !== null ? inputs : [getter];
+
     if (currentComponent.isCollectingHooks) {
         const value = getter();
-        hooks.push([HOOK_TYPE_USE_MEMO, value, inputs]);
+        hooks.push([HOOK_TYPE_USE_MEMO, value, inputsNext]);
         return value;
     }
 
     const hook = hooks[hooksPointer];
     const valuePrev = hook[1];
     const inputsPrev = hook[2];
-    const dirty =
-        inputs && inputs.length && !shallowEqualsArray(inputsPrev, inputs);
+    const dirty = !shallowEqualsArray(inputsPrev, inputsNext);
 
     if (!dirty) return valuePrev;
 
     // Update value
-    const value = getter();
-    hook[1] = value;
-    hook[2] = inputs;
-    return value;
+    const valueNext = getter();
+    hook[1] = valueNext;
+    hook[2] = inputsNext;
+    return valueNext;
 };


### PR DESCRIPTION
This is the follow-up PR for #78 It fixes the mentioned issues.

#### Explain the problem
We have some inconsistencies in the way how `inputs` (second argument of `useEffect`, `useMemo`, `useCallback`) are handled

#### Expected Behaviour

All hooks should have the same way of handling `inputs`. In React `useEffect`, `useMemo`, `useCallback` all have the same API:

```js
// useEffect
// called on mount & update
useEffect(fn);
// called on mount
useEffect(fn, []);
// called on mount & when input values change
useEffect(fn, [a, b]);

// Internal implementation
const dirty =
    !inputs || (inputs.length && !shallowEqualsArray(dataPrev, inputs));
```

#### Actual Behaviour

```js
// useEffect
// called on mount & update
useEffect(fn);
// called on mount
useEffect(fn, []);
// called on mount & when input values change
useEffect(fn, [a, b]);

// internal implementation
const dirty =
    !inputs || (inputs.length && !shallowEqualsArray(dataPrev, inputs));

// useCallback
// fn stored on mount (not stored on update! different from useEffect)
useCallback(fn);
// fn stored on mount
useCallback(fn, []);
// fn stored on mount & when input values change
useCallback(fn, [a, b]);

// internal implementation
const dirty =
    inputs && inputs.length && !shallowEqualsArray(inputsPrev, inputs);

// useMemo
// called on mount (not on update! different from useEffect)
useMemo(fn);
// called on mount
useMemo(fn, []);
// called on mount & when input values change, unmount
useMemo(fn, [a, b]);

// internal implementation
const dirty =
    inputs && inputs.length && !shallowEqualsArray(inputsPrev, inputs);

```
