### PR TITLE
Add initial draft of async mounting

### DIFF
--- a/packages/melody-compiler/__tests__/__fixtures__/error/empty_async_mount.template
+++ b/packages/melody-compiler/__tests__/__fixtures__/error/empty_async_mount.template
@@ -1,0 +1,2 @@
+{% mount async './parts/#{ part }.twig' as 'bar' with {foo: 'bar'} delay placeholder by 1s %}
+{% endmount %}

--- a/packages/melody-compiler/__tests__/__fixtures__/success/mount.template
+++ b/packages/melody-compiler/__tests__/__fixtures__/success/mount.template
@@ -3,5 +3,36 @@
 {% mount 'foo.twig' as 'bar' with {foo: 'bar'} %}
 
 {% mount Foo as 'bar' %}
-{% mount Foo as 'bar' with {foo: 'bar'} %}
+{% mount async as 'bar' with {foo: 'bar'} %}
 
+{% mount async 'foo.twig' as 'bar' with {foo: 'bar'} %}
+  Loading... {{ err }}
+{% catch err %}
+  Failed to load with {{ err }}
+{% endmount %}
+
+{% mount async 'foo.twig' as 'bar' with {foo: 'bar'} delay placeholder by 500ms %}
+  Loading... {{ err }}
+{% catch err %}
+  Failed to load with {{ err }}
+{% endmount %}
+
+{% mount async 'foo.twig' as 'bar' with {foo: 'bar'} delay placeholder by 1s %}
+  Loading... {{ err }}
+{% catch error %}
+  Failed to load with {{ error }} {{err}}
+{% endmount %}
+
+{% mount async './parts/#{ part }.twig' as 'bar-#{part}' with {foo: 'bar'} delay placeholder by 1s %}
+  Loading... {{ err }}
+{% catch err %}
+  Failed to load with {{ err }}
+{% endmount %}
+
+{% mount async './parts/#{ part }.twig' as 'bar' with {foo: 'bar'} delay placeholder by 1s %}
+  Loading... {{ err }}
+{% endmount %}
+
+{% mount async './parts/#{ part }.twig' as 'bar' with {foo: 'bar'} delay placeholder by 1s %}
+<strong>Loading...</strong>
+{% endmount %}

--- a/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -1588,8 +1588,9 @@ export default function Macros(props) {
 
 exports[`Compiler should correctly transform mount.template 1`] = `
 "
+import { AsyncComponent } from \\"melody-runtime\\";
 import Footwig from \\"foo.twig\\";
-import { component } from \\"melody-idom\\";
+import { component, text, elementOpen, elementClose } from \\"melody-idom\\";
 import Component from \\"./component\\";
 export const _template = {};
 
@@ -1600,8 +1601,92 @@ _template.render = function (_context) {
     foo: \\"bar\\"
   });
   component(_context.Foo, \\"bar\\");
-  component(_context.Foo, \\"bar\\", {
+  component(_context.async, \\"bar\\", {
     foo: \\"bar\\"
+  });
+  component(AsyncComponent, \\"bar\\", {
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"foo.twig\\"),
+    delayLoadingAnimation: 0,
+    whileLoading: () => {
+      text(\\" Loading... \\");
+      text(_context.err);
+    },
+    onError: err => {
+      text(\\" Failed to load with \\");
+      text(err);
+    },
+    data: {
+      foo: \\"bar\\"
+    }
+  });
+  component(AsyncComponent, \\"bar\\", {
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"foo.twig\\"),
+    delayLoadingAnimation: 500,
+    whileLoading: () => {
+      text(\\" Loading... \\");
+      text(_context.err);
+    },
+    onError: err => {
+      text(\\" Failed to load with \\");
+      text(err);
+    },
+    data: {
+      foo: \\"bar\\"
+    }
+  });
+  component(AsyncComponent, \\"bar\\", {
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"foo.twig\\"),
+    delayLoadingAnimation: 1000,
+    whileLoading: () => {
+      text(\\" Loading... \\");
+      text(_context.err);
+    },
+    onError: error => {
+      text(\\" Failed to load with \\");
+      text(error);
+      text(_context.err);
+    },
+    data: {
+      foo: \\"bar\\"
+    }
+  });
+  component(AsyncComponent, \\"\\" + (\\"bar-\\" + _context.part), {
+    promisedComponent: () => import( /* webpackPrefetch: true */\\"./parts/\\" + _context.part + \\".twig\\"),
+    delayLoadingAnimation: 1000,
+    whileLoading: () => {
+      text(\\" Loading... \\");
+      text(_context.err);
+    },
+    onError: err => {
+      text(\\" Failed to load with \\");
+      text(err);
+    },
+    data: {
+      foo: \\"bar\\"
+    }
+  });
+  component(AsyncComponent, \\"bar\\", {
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"./parts/\\" + _context.part + \\".twig\\"),
+    delayLoadingAnimation: 1000,
+    whileLoading: () => {
+      text(\\" Loading... \\");
+      text(_context.err);
+    },
+    data: {
+      foo: \\"bar\\"
+    }
+  });
+  component(AsyncComponent, \\"bar\\", {
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"./parts/\\" + _context.part + \\".twig\\"),
+    delayLoadingAnimation: 1000,
+    whileLoading: () => {
+      elementOpen(\\"strong\\", null, null);
+      text(\\"Loading...\\");
+      elementClose(\\"strong\\");
+    },
+    data: {
+      foo: \\"bar\\"
+    }
   });
 };
 
@@ -2177,6 +2262,19 @@ export default function Svg(props) {
   return _template.render(props);
 }
 "
+`;
+
+exports[`Compiler should fail transforming empty async mount.template 1`] = `
+"Asynchronously mounted components must have a placeholder
+> 1 | {% mount async './parts/#{ part }.twig' as 'bar' with {foo: 'bar'} delay placeholder by 1s %}
+    |    ^^^^^^^^^^^
+  2 | {% endmount %}
+  3 | 
+
+When using an async component you must provide a placeholder that can be rendered while your component is being loaded.
+Example:
+{% mount async 'my-component' as 'mycomp' %}
+This is the placeholder content that will be shown to your users while the async component is being loaded."
 `;
 
 exports[`Compiler should fail transforming unknown filter.template 1`] = `

--- a/packages/melody-extension-core/src/types.js
+++ b/packages/melody-extension-core/src/types.js
@@ -61,18 +61,33 @@ export class MountStatement extends Node {
         name?: Identifier,
         source?: String,
         key?: Node,
-        argument?: Node
+        argument?: Node,
+        async?: Boolean,
+        delayBy?: Number
     ) {
         super();
         this.name = name;
         this.source = source;
         this.key = key;
         this.argument = argument;
+        this.async = async;
+        this.delayBy = delayBy;
+        this.errorVariableName = null;
+        this.body = null;
+        this.otherwise = null;
     }
 }
 type(MountStatement, 'MountStatement');
-alias(MountStatement, 'Statement');
-visitor(MountStatement, 'name', 'source', 'key', 'argument');
+alias(MountStatement, 'Statement', 'Scope');
+visitor(
+    MountStatement,
+    'name',
+    'source',
+    'key',
+    'argument',
+    'body',
+    'otherwise'
+);
 
 export class DoStatement extends Node {
     constructor(expression: Node) {

--- a/packages/melody-runtime/__tests__/AsyncComponentSpec.js
+++ b/packages/melody-runtime/__tests__/AsyncComponentSpec.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    patch,
+    elementOpen,
+    text,
+    component,
+    elementClose,
+    enqueueComponent,
+    flush,
+} from 'melody-idom';
+import { AsyncComponent } from '../src';
+
+describe('AsyncComponent', () => {
+    let unmounted = false;
+    let notified = false;
+    let el = null;
+
+    beforeEach(function() {
+        unmounted = false;
+        notified = false;
+        el = document.createElement('div');
+    });
+
+    class Component {
+        constructor() {
+            this.el = null;
+            this.refs = Object.create(null);
+            this.props = null;
+        }
+
+        apply(props) {
+            this.props = props;
+            enqueueComponent(this);
+        }
+
+        notify() {
+            notified = true;
+        }
+
+        componentWillUnmount() {
+            unmounted = true;
+        }
+
+        render() {
+            elementOpen('div');
+            text(this.props.text);
+            elementClose('div');
+        }
+    }
+    it('should render a promised component', async function() {
+        const template = data => {
+            component(AsyncComponent, 'test', {
+                promisedComponent: () => Promise.resolve(Component),
+                whileLoading: () => {
+                    elementOpen('b');
+                    text('Loading...');
+                    elementClose('b');
+                },
+                onError: error => {
+                    elementOpen('strong');
+                    text(error);
+                    elementClose('strong');
+                },
+                data,
+            });
+            component(AsyncComponent, 'test_failure', {
+                promisedComponent: () =>
+                    Promise.reject('Network connection issue'),
+                whileLoading: () => {
+                    elementOpen('b');
+                    text('Loading...');
+                    elementClose('b');
+                },
+                onError: error => {
+                    elementOpen('strong');
+                    text(error);
+                    elementClose('strong');
+                },
+                data,
+            });
+        };
+        patch(el, template, { text: 'Hello' });
+        expect(el.innerHTML).toEqual(
+            '<m-placeholder></m-placeholder><m-placeholder></m-placeholder>'
+        );
+        run(2);
+        expect(el.innerHTML).toEqual('<b>Loading...</b><b>Loading...</b>');
+        await Promise.resolve();
+        run(2);
+        expect(el.innerHTML).toEqual(
+            '<div>Hello</div><strong>Network connection issue</strong>'
+        );
+
+        patch(el, template, { text: 'Foo' });
+        run();
+        expect(el.innerHTML).toEqual(
+            '<div>Foo</div><strong>Network connection issue</strong>'
+        );
+
+        expect(unmounted).toEqual(false);
+    });
+});
+
+function run(rounds = 1) {
+    for (var i = 0; i < rounds; i++) {
+        flush({
+            didTimeout: false,
+            timeRemaining() {
+                return 0;
+            },
+        });
+    }
+}

--- a/packages/melody-runtime/package.json
+++ b/packages/melody-runtime/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "lodash": "^4.12.0"
   },
+  "peerDependencies": {
+    "melody-idom": "^1.2.0"
+  },
   "devDependencies": {
     "rollup-plugin-babel": "^2.6.1"
   }

--- a/packages/melody-runtime/src/async.js
+++ b/packages/melody-runtime/src/async.js
@@ -1,0 +1,85 @@
+import { enqueueComponent, link } from 'melody-idom';
+
+export default class AsyncComponent {
+    constructor() {
+        this.promisedComponent = null;
+        this._el = null;
+        this.refs = Object.create(null);
+        this.props = null;
+        this.resolvedComponent = null;
+        this.alreadyUnmounted = false;
+        this.isLoading = false;
+        this.loadingError = null;
+    }
+
+    set el(el) {
+        if (this.resolvedComponent) {
+            this.resolvedComponent.el = el;
+        }
+        this._el = el;
+        return el;
+    }
+
+    get el() {
+        return this.resolvedComponent ? this.resolvedComponent.el : this._el;
+    }
+
+    apply(props) {
+        this.props = props;
+        const { promisedComponent } = props;
+        // if we already have resolved the component, just pass the data forward
+        if (this.resolvedComponent) {
+            this.resolvedComponent.apply(this.props.data);
+        }
+        // otherwise
+        if (!this.isLoading) {
+            this.isLoading = true;
+            promisedComponent()
+                .then(
+                    Component => {
+                        if (this.alreadyUnmounted) {
+                            return;
+                        }
+                        this.resolvedComponent = new Component();
+                        link(this, this.resolvedComponent);
+                        this.resolvedComponent.el = this._el;
+                        this.resolvedComponent.apply(this.props.data);
+                    },
+                    err => {
+                        // fail early
+                        this.loadingError = err;
+                        enqueueComponent(this);
+                    }
+                )
+                .catch(err => {
+                    // just in case something went wrong while initialising the component
+                    this.loadingError = err;
+                    enqueueComponent(this);
+                });
+            if (this.props.delayLoadingAnimation) {
+                setTimeout(
+                    () => enqueueComponent(this),
+                    this.props.delayLoadingAnimation
+                );
+            } else {
+                enqueueComponent(this);
+            }
+        }
+    }
+
+    notify() {}
+
+    componentWillUnmount() {
+        this.alreadyUnmounted = true;
+    }
+
+    render() {
+        if (!this.resolvedComponent) {
+            if (this.loadingError && this.props.onError) {
+                this.props.onError(this.loadingError);
+            } else {
+                this.props.whileLoading();
+            }
+        }
+    }
+}

--- a/packages/melody-runtime/src/index.js
+++ b/packages/melody-runtime/src/index.js
@@ -33,3 +33,6 @@ export {
 } from './filters';
 export { random, min, max, cycle, attribute } from './functions';
 export { isEmpty, inheritBlocks } from './helpers';
+
+import AsyncComponent from './async';
+export { AsyncComponent };


### PR DESCRIPTION
#### What changed in this PR:

Introduced async mounting runtime and compiler support.

```
{% mount async './parts/#{ part }.twig' as 'bar-#{part}' with {foo: 'bar'} delay placeholder by 1s %}
  Loading... {{ err }}
{% catch err %}
  Failed to load with {{ err }}
{% endmount %}
```

Supports dynamic component loading, showing a loading message as well as showing an error. The placeholder can be delayed by a fixed amount of time.