### PR TITLE
Catch errors in component function

### DIFF
--- a/packages/melody-hooks/__tests__/ComponentSpec.js
+++ b/packages/melody-hooks/__tests__/ComponentSpec.js
@@ -611,7 +611,8 @@ describe('component', () => {
 
         const root = document.createElement('div');
         const MyComponent = createComponent(props => {
-            return { value: props.value };
+            if (!props) throw new Error('Foo');
+            return props;
         }, template);
         assert.throws(() => {
             render(root, MyComponent);

--- a/packages/melody-hooks/__tests__/ComponentSpec.js
+++ b/packages/melody-hooks/__tests__/ComponentSpec.js
@@ -23,7 +23,7 @@ import {
     component,
     patchOuter,
 } from 'melody-idom';
-import { createComponent, useEffect, useEffectOnce } from '../src';
+import { createComponent, useEffect, useEffectOnce, useState } from '../src';
 import { flush } from './util/flush';
 
 const template = {
@@ -612,14 +612,22 @@ describe('component', () => {
         const root = document.createElement('div');
         const MyComponent = createComponent(props => {
             if (!props) throw new Error('Foo');
-            return props;
+            const [foo] = useState(1337);
+            const [bar] = useState(1337);
+            return {
+                ...props,
+                foo,
+                bar,
+            };
         }, template);
+
+        render(root, MyComponent, { value: 'foo' });
+        assert.equal(root.outerHTML, '<div>foo</div>');
         assert.throws(() => {
             render(root, MyComponent);
         });
-        assert.equal(root.outerHTML, '<div></div>');
+        assert.equal(root.outerHTML, '<div>foo</div>');
         render(root, MyComponent, { value: 'foo' });
-        flush();
         assert.equal(root.outerHTML, '<div>foo</div>');
     });
 });

--- a/packages/melody-hooks/__tests__/ComponentSpec.js
+++ b/packages/melody-hooks/__tests__/ComponentSpec.js
@@ -443,7 +443,7 @@ describe('component', () => {
         assert.equal(mounted, 0);
     });
     it('should trigger unmount callback for deep nested child components when a Component is removed', () => {
-        let mounted = { inner: 0, middle: 0, outer: 0 };
+        const mounted = { inner: 0, middle: 0, outer: 0 };
         const root = document.createElement('div');
         const CountInstances = name => props => {
             useEffectOnce(() => {
@@ -501,7 +501,7 @@ describe('component', () => {
         assert.equal(mounted.outer, 0);
     });
     it('should trigger unmount callback for deep nested child components when a Component is removed', () => {
-        let mounted = { innermost: 0, inner: 0, middle: 0, outer: 0 };
+        const mounted = { innermost: 0, inner: 0, middle: 0, outer: 0 };
         const root = document.createElement('div');
         const CountInstances = name => props => {
             useEffectOnce(() => {
@@ -599,5 +599,26 @@ describe('component', () => {
         render(root, MyParentComponent, { childProps: { text: 'test' } });
         assert.equal(root.outerHTML, '<div><div>test</div></div>');
         assert.equal(mounted, 1);
+    });
+    it('should recover from errors in the component function', () => {
+        const template = {
+            render(_context) {
+                elementOpen('div', null, null);
+                text(_context.value);
+                elementClose('div');
+            },
+        };
+
+        const root = document.createElement('div');
+        const MyComponent = createComponent(props => {
+            return { value: props.value };
+        }, template);
+        assert.throws(() => {
+            render(root, MyComponent);
+        });
+        assert.equal(root.outerHTML, '<div></div>');
+        render(root, MyComponent, { value: 'foo' });
+        flush();
+        assert.equal(root.outerHTML, '<div>foo</div>');
     });
 });


### PR DESCRIPTION
While writing tests for some custom hooks, I came across an issue with errors that are thrown inside the component function. If an error occurs while in the component function loop, the hooks internals are not cleaned up (e.g. `unsetCurrentComponent()` is not called). So after such an error the whole library is not usable any more. This PR fixes the issue
