### PR TITLE
Add dom testing library

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "common-tags": "^1.3.1",
         "coveralls": "^3.0.0",
         "cross-env": "^3.2.3",
+        "dom-testing-library": "^3.16.3",
         "eslint": "^3.17.1",
         "eslint-config-idiomatic": "^3.1.0",
         "eslint-config-prettier": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "common-tags": "^1.3.1",
         "coveralls": "^3.0.0",
         "cross-env": "^3.2.3",
-        "dom-testing-library": "^3.16.3",
         "eslint": "^3.17.1",
         "eslint-config-idiomatic": "^3.1.0",
         "eslint-config-prettier": "^2.3.0",

--- a/packages/melody-test-utils/__tests__/__fixtures__/input.js
+++ b/packages/melody-test-utils/__tests__/__fixtures__/input.js
@@ -1,0 +1,35 @@
+import template from './input.twig';
+import { createComponent, RECEIVE_PROPS } from 'melody-component';
+import { bindEvents } from 'melody-hoc';
+
+const reducer = (state = { value: 'hello, melody' }, action) => {
+    switch (action.type) {
+        case RECEIVE_PROPS:
+            return {
+                ...state,
+                ...action.payload,
+            };
+        case 'CHANGE':
+            return {
+                ...state,
+                ...action.payload,
+            };
+        default:
+            return state;
+    }
+};
+
+const eventEnhancer = bindEvents({
+    input: {
+        input(event, { dispatch }) {
+            dispatch({
+                type: 'CHANGE',
+                payload: {
+                    value: event.target.value,
+                },
+            });
+        },
+    },
+});
+
+export default eventEnhancer(createComponent(template, reducer, {}));

--- a/packages/melody-test-utils/__tests__/__fixtures__/input.twig
+++ b/packages/melody-test-utils/__tests__/__fixtures__/input.twig
@@ -1,0 +1,3 @@
+<div>
+  <input type="text" ref="{{ input }}" value="{{ value }}"/>
+</div>

--- a/packages/melody-test-utils/__tests__/__fixtures__/input.twig
+++ b/packages/melody-test-utils/__tests__/__fixtures__/input.twig
@@ -1,3 +1,3 @@
 <div>
-  <input type="text" ref="{{ input }}" value="{{ value }}"/>
+    <input type="text" ref="{{ input }}" value="{{ value }}"/>
 </div>

--- a/packages/melody-test-utils/__tests__/__snapshots__/renderSpec.js.snap
+++ b/packages/melody-test-utils/__tests__/__snapshots__/renderSpec.js.snap
@@ -120,6 +120,20 @@ FullWrapper {
 
 exports[`Full rendering should allow simulating events 2`] = `"<li><h2>Foo</h2><div class=\\"message\\">I have been clicked!</div></li><li><h2>Bar</h2></li>"`;
 
+exports[`Full rendering should allow simulating input events 1`] = `
+FullWrapper {
+  "elements": Array [
+    <div>
+      <input
+        type="text"
+      />
+    </div>,
+  ],
+}
+`;
+
+exports[`Full rendering should allow simulating input events 2`] = `"<input type=\\"text\\">"`;
+
 exports[`Full rendering should find the child Components 1`] = `
 FullWrapper {
   "elements": Array [

--- a/packages/melody-test-utils/__tests__/renderSpec.js
+++ b/packages/melody-test-utils/__tests__/renderSpec.js
@@ -1,5 +1,6 @@
 import List from './__fixtures__/list.js';
 import Item from './__fixtures__/item.js';
+import Input from './__fixtures__/input.js';
 import { render } from '../src';
 import { RECEIVE_PROPS } from 'melody-component';
 
@@ -104,6 +105,27 @@ describe('Full rendering', () => {
         ).toMatch(/I have been clicked!/);
         expect(result).toMatchSnapshot();
         expect(result.find(Item).html()).toMatchSnapshot();
+    });
+
+    it('should allow simulating input events', () => {
+        const result = render(Input, {});
+        result
+            .find('input')
+            .at(0)
+            .simulate('input', { target: { value: 'mocked_value' } });
+        expect(result.state().value).toMatch(/mocked_value/);
+        expect(result).toMatchSnapshot();
+        expect(result.find('input').html()).toMatchSnapshot();
+    });
+
+    it('should throw when simulating an event that does not exist', () => {
+        const result = render(Input, {});
+        expect(() =>
+            result
+                .find('input')
+                .at(0)
+                .simulate('foo', { target: { value: 'mocked_value' } })
+        ).toThrowError('No event found of type: "foo"');
     });
 
     it('should return whether an element has a class or not', () => {

--- a/packages/melody-test-utils/package.json
+++ b/packages/melody-test-utils/package.json
@@ -1,22 +1,23 @@
 {
-  "name": "melody-test-utils",
-  "version": "1.2.0-0",
-  "description": "",
-  "main": "./lib/index.js",
-  "jsnext:main": "./lib/index.esm.js",
-  "scripts": {
-    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
-  },
-  "author": "",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "pretty-format": "21.2.1"
-  },
-  "peerDependencies": {
-    "melody-idom": "^1.2.0",
-    "melody-snapshot-serializer": "^1.2.0"
-  },
-  "devDependencies": {
-    "rollup-plugin-babel": "^2.6.1"
-  }
+    "name": "melody-test-utils",
+    "version": "1.2.0-0",
+    "description": "",
+    "main": "./lib/index.js",
+    "jsnext:main": "./lib/index.esm.js",
+    "scripts": {
+        "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
+    },
+    "author": "",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "dom-testing-library": "^3.16.3",
+        "pretty-format": "21.2.1"
+    },
+    "peerDependencies": {
+        "melody-idom": "^1.2.0",
+        "melody-snapshot-serializer": "^1.2.0"
+    },
+    "devDependencies": {
+        "rollup-plugin-babel": "^2.6.1"
+    }
 }

--- a/packages/melody-test-utils/package.json
+++ b/packages/melody-test-utils/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "melody-test-utils",
-    "version": "1.2.0-0",
-    "description": "",
-    "main": "./lib/index.js",
-    "jsnext:main": "./lib/index.esm.js",
-    "scripts": {
-        "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
-    },
-    "author": "",
-    "license": "Apache-2.0",
-    "dependencies": {
-        "dom-testing-library": "^3.16.3",
-        "pretty-format": "21.2.1"
-    },
-    "peerDependencies": {
-        "melody-idom": "^1.2.0",
-        "melody-snapshot-serializer": "^1.2.0"
-    },
-    "devDependencies": {
-        "rollup-plugin-babel": "^2.6.1"
-    }
+  "name": "melody-test-utils",
+  "version": "1.2.0-0",
+  "description": "",
+  "main": "./lib/index.js",
+  "jsnext:main": "./lib/index.esm.js",
+  "scripts": {
+    "build": "mkdir lib; rollup -c ../../rollup.config.js -i src/index.js"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "dom-testing-library": "^3.16.3",
+    "pretty-format": "21.2.1"
+  },
+  "peerDependencies": {
+    "melody-idom": "^1.2.0",
+    "melody-snapshot-serializer": "^1.2.0"
+  },
+  "devDependencies": {
+    "rollup-plugin-babel": "^2.6.1"
+  }
 }

--- a/packages/melody-test-utils/src/index.js
+++ b/packages/melody-test-utils/src/index.js
@@ -14,6 +14,8 @@ import { print, test } from 'melody-snapshot-serializer';
 
 import prettyFormat from 'pretty-format';
 
+import { fireEvent } from 'dom-testing-library';
+
 const flatten = nestedArray =>
     nestedArray.reduce((acc, cur) => acc.concat(cur), []);
 const map = transform => data => data.map(transform);
@@ -284,8 +286,13 @@ export class Wrapper {
     }
 
     simulate(type, options = { bubbles: true }) {
-        const event = new Event(type, options);
-        this.forEach(el => el.dispatchEvent(event));
+        const dispatchEvent = fireEvent[type];
+
+        if (!dispatchEvent) {
+            throw new TypeError(`No event found of type: "${type}"`);
+        }
+
+        this.forEach(el => dispatchEvent(el, options));
         drainQueue();
         return this;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,13 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.1.5":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
@@ -29,6 +36,11 @@
     esutils "^2.0.2"
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
+
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -2008,6 +2020,16 @@ doctrine@^2.0.0:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
+
+dom-testing-library@^3.16.3:
+  version "3.16.3"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.16.3.tgz#9dbf88d0a0c12f653248ad8f2a5aa17cc66f85e9"
+  integrity sha512-AZJJ/lmw+/yZxUVWoua5BofYK9EAQ/7Ai2wldUb6mSjE1XZy2H/+IrhG57lp3GqYN5WK7c2HzBLu8lW3c6/bXQ==
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^23.6.0"
+    wait-for-expect "^1.1.0"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -4525,7 +4547,7 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-"micromatch@github:jonschlinkert/micromatch#2.2.0":
+micromatch@jonschlinkert/micromatch#2.2.0:
   version "2.2.0"
   resolved "https://codeload.github.com/jonschlinkert/micromatch/tar.gz/5017fd78202e04c684cc31d3c2fb1f469ea222ff"
   dependencies:
@@ -5236,6 +5258,14 @@ pretty-format@^22.4.0, pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
+  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 prettycli@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/prettycli/-/prettycli-1.4.3.tgz#b28ec2aad9de07ae1fd75ef294fb54cbdee07ed5"
@@ -5465,6 +5495,11 @@ regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -6548,6 +6583,11 @@ w3c-hr-time@^1.0.1:
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-expect@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.1.0.tgz#6607375c3f79d32add35cd2c87ce13f351a3d453"
+  integrity sha512-vQDokqxyMyknfX3luCDn16bSaRcOyH6gGuUXMIbxBLeTo6nWuEWYqMTT9a+44FmW8c2m6TRWBdNvBBjA1hwEKg==
 
 walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,13 +22,6 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/runtime@^7.1.5":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
-  integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
-  dependencies:
-    regenerator-runtime "^0.12.0"
-
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
@@ -36,11 +29,6 @@
     esutils "^2.0.2"
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
-
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
-  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -2020,16 +2008,6 @@ doctrine@^2.0.0:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
-
-dom-testing-library@^3.16.3:
-  version "3.16.3"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.16.3.tgz#9dbf88d0a0c12f653248ad8f2a5aa17cc66f85e9"
-  integrity sha512-AZJJ/lmw+/yZxUVWoua5BofYK9EAQ/7Ai2wldUb6mSjE1XZy2H/+IrhG57lp3GqYN5WK7c2HzBLu8lW3c6/bXQ==
-  dependencies:
-    "@babel/runtime" "^7.1.5"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^23.6.0"
-    wait-for-expect "^1.1.0"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -5258,14 +5236,6 @@ pretty-format@^22.4.0, pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
-  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
-  dependencies:
-    ansi-regex "^3.0.0"
-    ansi-styles "^3.2.0"
-
 prettycli@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/prettycli/-/prettycli-1.4.3.tgz#b28ec2aad9de07ae1fd75ef294fb54cbdee07ed5"
@@ -5495,11 +5465,6 @@ regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-
-regenerator-runtime@^0.12.0:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
-  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -6583,11 +6548,6 @@ w3c-hr-time@^1.0.1:
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:
     browser-process-hrtime "^0.1.2"
-
-wait-for-expect@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.1.0.tgz#6607375c3f79d32add35cd2c87ce13f351a3d453"
-  integrity sha512-vQDokqxyMyknfX3luCDn16bSaRcOyH6gGuUXMIbxBLeTo6nWuEWYqMTT9a+44FmW8c2m6TRWBdNvBBjA1hwEKg==
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
#### Reference issue: [#83](https://github.com/trivago/melody/issues/83)

#### What changed in this PR:

In order to allow `melody-test-utils` to simulate most events properly, Kent C Dodd's `dom-testing-library` has been added and replaces the `Event` constructor in `Wrapper.simulate`. This will allow for keyboard and input events to be simulated properly, including being able to test for proper handling of `event.target.value`.