### PR TITLE
prevent child components with no props from rerendering

### DIFF
--- a/packages/melody-hooks/__tests__/ComponentSpec.js
+++ b/packages/melody-hooks/__tests__/ComponentSpec.js
@@ -88,6 +88,37 @@ describe('component', () => {
         render(root, MyComponent, { value: 'foo' });
         assert.equal(called, 1);
     });
+    it("should not rerender children when props haven't changed", () => {
+        const childTemplate = {
+            render(_context) {
+                elementOpen('div', null, null);
+                text('Hello');
+                elementClose('div');
+            },
+        };
+
+        let childCalled = 0;
+        const MyComponent = createComponent(props => {
+            childCalled++;
+        }, childTemplate);
+
+        const parentTemplate = {
+            render(_context) {
+                elementOpen('div', null, null);
+                component(MyComponent, '4');
+                elementClose('div');
+            },
+        };
+        const MyParentComponent = createComponent(
+            props => props,
+            parentTemplate
+        );
+
+        const root = document.createElement('div');
+        render(root, MyParentComponent);
+        render(root, MyParentComponent);
+        expect(childCalled).toEqual(1);
+    });
     it('should replace components', () => {
         const template = {
             render(_context) {
@@ -611,7 +642,7 @@ describe('component', () => {
 
         const root = document.createElement('div');
         const MyComponent = createComponent(props => {
-            if (!props) throw new Error('Foo');
+            if (!props.value) throw new Error('Foo');
             const [foo] = useState(1337);
             const [bar] = useState(1337);
             return {

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -60,7 +60,8 @@ function Component(element, componentFn) {
     this.hooksPointer = -1;
 
     // the props the we receive from the parent
-    this.props = null;
+    // this.props = null;
+    this.props = undefined;
     // receiving new props marks the props as dirty
     this.isPropsDirty = false;
 
@@ -90,11 +91,11 @@ Object.assign(Component.prototype, {
      * @param {*} props new properties
      */
     apply(props) {
-        if (shallowEquals(props, this.props)) {
-            return;
-        }
-        this.props = props || null;
-        this.isPropsDirty = true;
+        // On the first call to apply `this.props` is null, thus
+        // `isPropsDirty` will be true.
+        const propsNext = props || {};
+        this.isPropsDirty = !shallowEquals(propsNext, this.props);
+        this.props = propsNext;
         this.enqueueComponent();
     },
 

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -91,7 +91,7 @@ Object.assign(Component.prototype, {
      * @param {*} props new properties
      */
     apply(props) {
-        // On the first call to apply `this.props` is null, thus
+        // On the first call to apply `this.props` is `undefined`, thus
         // `isPropsDirty` will be true.
         const propsNext = props || {};
         this.isPropsDirty = !shallowEquals(propsNext, this.props);

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -59,8 +59,8 @@ function Component(element, componentFn) {
     // tracks which hook is currently running
     this.hooksPointer = -1;
 
-    // the props the we receive from the parent
-    // this.props = null;
+    // `this.props` need to be initialized with `undefined`
+    // for first shallowEqual check in `apply`
     this.props = undefined;
     // receiving new props marks the props as dirty
     this.isPropsDirty = false;


### PR DESCRIPTION
There is a bug with hooks components, that leads to child components that have no props defined (e.g. by calling them like `component(MyComponent, 'my-comp');` in the template, will always rerender.

This PR fixes the bug, by always ensuring that props are an object