### PR TITLE
Hooks bugfixes

### DIFF
--- a/packages/melody-hooks/__tests__/ComponentSpec.js
+++ b/packages/melody-hooks/__tests__/ComponentSpec.js
@@ -639,7 +639,15 @@ describe('component', () => {
         }, template);
         render(root, MyComponent);
         unmountComponentAtNode(root);
+        /* eslint-disable no-console */
+        const temp = console.warn;
+        console.warn = jest.fn();
         rerender('foo');
+        expect(console.warn).toHaveBeenCalledWith(
+            'useState: a `setState` handler has been called even though the component was already unmounted. This is probably due to a missing `unsubscribe` callback of a `useEffect` or `useMutationEffect` hook.'
+        );
+        console.warn = temp;
+        /* eslint-enable no-console */
     });
     it('should recover from errors in the component function', () => {
         const template = {

--- a/packages/melody-hooks/__tests__/ComponentSpec.js
+++ b/packages/melody-hooks/__tests__/ComponentSpec.js
@@ -15,7 +15,7 @@
  */
 import { assert } from 'chai';
 
-import { render } from 'melody-component';
+import { render, unmountComponentAtNode } from 'melody-component';
 import {
     elementOpen,
     elementClose,
@@ -630,6 +630,16 @@ describe('component', () => {
         render(root, MyParentComponent, { childProps: { text: 'test' } });
         assert.equal(root.outerHTML, '<div><div>test</div></div>');
         assert.equal(mounted, 1);
+    });
+    it('should not throw when calling setState after the component has been unmounted', () => {
+        const root = document.createElement('div');
+        let rerender;
+        const MyComponent = createComponent(() => {
+            rerender = useState()[1];
+        }, template);
+        render(root, MyComponent);
+        unmountComponentAtNode(root);
+        rerender('foo');
     });
     it('should recover from errors in the component function', () => {
         const template = {

--- a/packages/melody-hooks/__tests__/UseEffectSpec.js
+++ b/packages/melody-hooks/__tests__/UseEffectSpec.js
@@ -103,6 +103,38 @@ describe('useEffect', () => {
             assert.equal(root.outerHTML, '<div>1</div>');
             assert.equal(called, 2);
         });
+        it('should not reset `dirty` when multiple updates come in', () => {
+            const root = document.createElement('div');
+            let called = 0;
+            let setValue;
+            const MyComponent = createComponent(() => {
+                const state = useState([]);
+                const value = state[0];
+                setValue = state[1];
+                useEffect(
+                    () => {
+                        called++;
+                    },
+                    // note: we are using derived data (value.length) here
+                    [value.length]
+                );
+                return {
+                    value,
+                };
+            }, template);
+            render(root, MyComponent);
+            assert.equal(called, 1);
+            setValue(['a']);
+            flush();
+            assert.equal(called, 2);
+            setValue(['a', 'b']);
+            // the second call to setValue should not reset the hook's internal `dirty` property,
+            // value.length will be 2 for both times `setValue` is called.
+            // here we test that once dirty is true, it will not be resetted
+            setValue(['a', 'c']);
+            flush();
+            assert.equal(called, 3);
+        });
         it('should ignore unsubscribe if it is not a function', () => {
             const root = document.createElement('div');
             const MyComponent = createComponent(() => {

--- a/packages/melody-hooks/__tests__/UseEffectSpec.js
+++ b/packages/melody-hooks/__tests__/UseEffectSpec.js
@@ -103,6 +103,14 @@ describe('useEffect', () => {
             assert.equal(root.outerHTML, '<div>1</div>');
             assert.equal(called, 2);
         });
+        it('should ignore unsubscribe if it is not a function', () => {
+            const root = document.createElement('div');
+            const MyComponent = createComponent(() => {
+                useEffect(() => 'not a function');
+            }, template);
+            render(root, MyComponent);
+            unmountComponentAtNode(root);
+        });
     });
     describe('with unsubscribe', () => {
         it('should call effect on mount and every update and unsubscribe after every update and on unmount', () => {

--- a/packages/melody-hooks/__tests__/UseEffectSpec.js
+++ b/packages/melody-hooks/__tests__/UseEffectSpec.js
@@ -141,7 +141,17 @@ describe('useEffect', () => {
                 useEffect(() => 'not a function');
             }, template);
             render(root, MyComponent);
+
+            /* eslint-disable no-console */
+            const temp = console.warn;
+            console.warn = jest.fn();
             unmountComponentAtNode(root);
+
+            expect(console.warn).toHaveBeenCalledWith(
+                'useEffect: expected the unsubscribe callback to be a function or undefined. Instead received string.'
+            );
+            console.warn = temp;
+            /* eslint-enable no-console */
         });
     });
     describe('with unsubscribe', () => {

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -423,7 +423,9 @@ Object.assign(Component.prototype, {
                 case HOOK_TYPE_USE_EFFECT:
                 case HOOK_TYPE_USE_MUTATION_EFFECT: {
                     const unsubscribe = hook[4];
-                    if (unsubscribe) unsubscribe();
+                    if (typeof unsubscribe === 'function') {
+                        unsubscribe();
+                    }
                     break;
                 }
                 // Unset references to DOM elements

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -166,7 +166,11 @@ Object.assign(Component.prototype, {
                 markEnd(this, `${HOOK_LABEL_BY_TYPE[hookType]} (${i})`);
             }
 
+            // store new unsubscribe callback
             hook[4] = unsubscribeNext;
+
+            // effect is not dirty anymore
+            hook[3] = false;
         }
     },
 

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -437,6 +437,17 @@ Object.assign(Component.prototype, {
                     const unsubscribe = hook[4];
                     if (typeof unsubscribe === 'function') {
                         unsubscribe();
+                    } else {
+                        if (process.env.NODE_ENV !== 'production') {
+                            if (unsubscribe !== undefined) {
+                                const hookLabel = HOOK_LABEL_BY_TYPE[type];
+                                // eslint-disable-next-line no-console
+                                console.warn(
+                                    `${hookLabel}: expected the unsubscribe callback to be ` +
+                                        `a function or undefined. Instead received ${typeof unsubscribe}.`
+                                );
+                            }
+                        }
                     }
                     break;
                 }

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -226,6 +226,14 @@ Object.assign(Component.prototype, {
         } = this;
 
         if (isUnmounted) {
+            if (process.env.NODE_ENV !== 'production') {
+                // eslint-disable-next-line no-console
+                console.warn(
+                    'useState: a `setState` handler has been called even though the component ' +
+                        'was already unmounted. This is probably due to a missing `unsubscribe` ' +
+                        'callback of a `useEffect` or `useMutationEffect` hook.'
+                );
+            }
             return;
         }
 

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -84,6 +84,7 @@ function Component(element, componentFn) {
     // tracks whether this component is mounted and
     // attached to the DOM
     this.isMounted = false;
+    this.isUnmounted = false;
 
     // Tracks whether this component was enqued but never renderd
     this.needsRender = false;
@@ -213,11 +214,16 @@ Object.assign(Component.prototype, {
      */
     setState(hookIndex, valueNext) {
         const {
+            isUnmounted,
             state,
             stateQueue,
             hasQueuedState,
             isRunningMutationEffects,
         } = this;
+
+        if (isUnmounted) {
+            return;
+        }
 
         if (isRunningMutationEffects) {
             throw new Error(
@@ -435,6 +441,7 @@ Object.assign(Component.prototype, {
             markEnd(this, 'unmount');
         }
         // Unset hooks
+        this.isUnmounted = true;
         this.hooks = undefined;
     },
 });

--- a/packages/melody-hooks/src/hooks/useEffect.js
+++ b/packages/melody-hooks/src/hooks/useEffect.js
@@ -42,6 +42,8 @@ const createEffectHook = type => (callback, inputs) => {
         hook[1] = callback;
     }
     hook[2] = inputsNext;
+
+    // Do not reset `dirty` when it is already `true`
     hook[3] = hook[3] || dirty;
 };
 

--- a/packages/melody-hooks/src/hooks/useEffect.js
+++ b/packages/melody-hooks/src/hooks/useEffect.js
@@ -42,7 +42,7 @@ const createEffectHook = type => (callback, inputs) => {
         hook[1] = callback;
     }
     hook[2] = inputsNext;
-    hook[3] = dirty;
+    hook[3] = hook[3] || dirty;
 };
 
 export const useEffect = createEffectHook(HOOK_TYPE_USE_EFFECT);


### PR DESCRIPTION
This PR fixes two issues I came across while implementing a fast changing UI:

* should not throw when calling `setState` after the component has been unmounted and warn the developer
* should ignore `unsubscribe` if it is not a function and warn the developer.
* do not reset useEffect internal `dirty` property when multiple updates come in

