### PR TITLE
fixed a bug with the warning about unsubscribe

### DIFF
--- a/packages/melody-hooks/__tests__/UseEffectSpec.js
+++ b/packages/melody-hooks/__tests__/UseEffectSpec.js
@@ -140,12 +140,11 @@ describe('useEffect', () => {
             const MyComponent = createComponent(() => {
                 useEffect(() => 'not a function');
             }, template);
-            render(root, MyComponent);
 
             /* eslint-disable no-console */
             const temp = console.warn;
             console.warn = jest.fn();
-            unmountComponentAtNode(root);
+            render(root, MyComponent);
 
             expect(console.warn).toHaveBeenCalledWith(
                 'useEffect: expected the unsubscribe callback to be a function or undefined. Instead received string.'

--- a/packages/melody-hooks/__tests__/UseMutationEffectSpec.js
+++ b/packages/melody-hooks/__tests__/UseMutationEffectSpec.js
@@ -43,8 +43,12 @@ describe('useMutationEffect', () => {
             const root = document.createElement('div');
             const log = [];
             const MyComponent = createComponent(() => {
-                useEffect(() => log.push('effect'));
-                useMutationEffect(() => log.push('mutation'));
+                useEffect(() => {
+                    log.push('effect');
+                });
+                useMutationEffect(() => {
+                    log.push('mutation');
+                });
             }, template);
             render(root, MyComponent);
             assert.deepEqual(log, ['mutation', 'effect']);

--- a/packages/melody-hooks/src/component.js
+++ b/packages/melody-hooks/src/component.js
@@ -161,9 +161,23 @@ Object.assign(Component.prototype, {
             if (process.env.NODE_ENV !== 'production') {
                 markStart(this, `${HOOK_LABEL_BY_TYPE[hookType]} (${i})`);
             }
-            const unsubscribeNext = callback() || null;
+            const unsubscribeNext = callback();
             if (process.env.NODE_ENV !== 'production') {
                 markEnd(this, `${HOOK_LABEL_BY_TYPE[hookType]} (${i})`);
+            }
+
+            if (process.env.NODE_ENV !== 'production') {
+                if (
+                    unsubscribeNext !== undefined &&
+                    typeof unsubscribeNext !== 'function'
+                ) {
+                    const hookLabel = HOOK_LABEL_BY_TYPE[type];
+                    // eslint-disable-next-line no-console
+                    console.warn(
+                        `${hookLabel}: expected the unsubscribe callback to be ` +
+                            `a function or undefined. Instead received ${typeof unsubscribeNext}.`
+                    );
+                }
             }
 
             // store new unsubscribe callback
@@ -437,17 +451,6 @@ Object.assign(Component.prototype, {
                     const unsubscribe = hook[4];
                     if (typeof unsubscribe === 'function') {
                         unsubscribe();
-                    } else {
-                        if (process.env.NODE_ENV !== 'production') {
-                            if (unsubscribe !== undefined) {
-                                const hookLabel = HOOK_LABEL_BY_TYPE[type];
-                                // eslint-disable-next-line no-console
-                                console.warn(
-                                    `${hookLabel}: expected the unsubscribe callback to be ` +
-                                        `a function or undefined. Instead received ${typeof unsubscribe}.`
-                                );
-                            }
-                        }
                     }
                     break;
                 }


### PR DESCRIPTION
This PR fixes the following bug
* we warn when the unsubscribe function (returned from `useEffect`/`useMutationEffect`) is not `undefined` or not a `function`. 
* when no function is returned we store a `null` value, which passes the warn test because `typeof null === 'object'`.
* the PR fixes the bug, and now warns early (as soon as the `unsubscribe` function is returned, and not when the component unmount)