### PR TITLE
Removes sinon and chai, Migration to Jest matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+### Chore & Maintenance
+- Removes `Chai` and `Sinon` support, Migrates tests to use `Jest`'s matchers. [#103](https://github.com/trivago/melody/pull/103)
+
 ## 1.2.0-4 (beta)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -55,8 +55,6 @@
         "babel-preset-react": "^6.23.0",
         "babel-register": "^6.23.0",
         "bundlesize": "^0.15.2",
-        "chai": "^3.0.0",
-        "chai-subset": "^1.5.0",
         "commitizen": "^2.9.6",
         "common-tags": "^1.3.1",
         "coveralls": "^3.0.0",
@@ -83,8 +81,6 @@
         "rollup-plugin-json": "^3.0.0",
         "rollup-plugin-uglify": "^4.0.0",
         "semver": "^5.5.1",
-        "sinon": "^1.17.7",
-        "sinon-chai": "^2.8.0",
         "source-map": "^0.5.6",
         "typescript": "^2.2.1",
         "typescript-babel-jest": "^1.0.5"

--- a/packages/melody-compiler/__tests__/AutoescapeSpec.js
+++ b/packages/melody-compiler/__tests__/AutoescapeSpec.js
@@ -13,13 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import chai from 'chai';
-import chaiSubset from 'chai-subset';
-import { expect } from 'chai';
+
 import { CharStream, Parser, TokenStream, Lexer } from 'melody-parser';
 import { extension } from 'melody-extension-core';
-
-chai.use(chaiSubset);
 
 describe('autoescape', function() {
     describe('when parsing', function() {
@@ -27,9 +23,9 @@ describe('autoescape', function() {
             const node = parse(
                 `{% autoescape 'html' %}
 Everything will be automatically escaped in this block using the {{ strategy }} strategy.
-{% endautoescape %}`,
+{% endautoescape %}`
             );
-            expect(node.expressions[0]).to.containSubset({
+            expect(node.expressions[0]).toMatchObject({
                 type: 'AutoescapeBlock',
                 escapeType: 'html',
                 expressions: [

--- a/packages/melody-compiler/__tests__/CharStreamSpec.js
+++ b/packages/melody-compiler/__tests__/CharStreamSpec.js
@@ -13,39 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 import { CharStream, EOF } from 'melody-parser';
 
 describe('CharStream', function() {
     describe('#la', function() {
         it('should return EOF at the end of input', function() {
             var stream = new CharStream('');
-            expect(stream.la(1)).to.equal(EOF);
+            expect(stream.la(1)).toEqual(EOF);
         });
 
         it('should return EOF when looking beyond the end of input', () => {
             var stream = new CharStream('hello');
-            expect(stream.la(10)).to.equal(EOF);
+            expect(stream.la(10)).toEqual(EOF);
         });
 
         it('should return the char at the specified offset', () => {
             var stream = new CharStream('hello');
-            expect(stream.la(0)).to.eql('h');
-            expect(stream.la(1)).to.eql('e');
-            expect(stream.la(2)).to.eql('l');
-            expect(stream.la(3)).to.eql('l');
-            expect(stream.la(4)).to.eql('o');
-            expect(stream.la(5)).to.equal(EOF);
+            expect(stream.la(0)).toEqual('h');
+            expect(stream.la(1)).toEqual('e');
+            expect(stream.la(2)).toEqual('l');
+            expect(stream.la(3)).toEqual('l');
+            expect(stream.la(4)).toEqual('o');
+            expect(stream.la(5)).toEqual(EOF);
         });
 
         it('should return the char from the current position', () => {
             var stream = new CharStream('hello');
             stream.next();
             stream.next();
-            expect(stream.la(0)).to.eql('l');
-            expect(stream.la(1)).to.eql('l');
-            expect(stream.la(2)).to.eql('o');
-            expect(stream.la(3)).to.equal(EOF);
+            expect(stream.la(0)).toEqual('l');
+            expect(stream.la(1)).toEqual('l');
+            expect(stream.la(2)).toEqual('o');
+            expect(stream.la(3)).toEqual(EOF);
         });
     });
 
@@ -53,25 +52,25 @@ describe('CharStream', function() {
         it('should advance to the next character', () => {
             var stream = new CharStream('hello');
             stream.next();
-            expect(stream.la(0)).to.eql('e');
+            expect(stream.la(0)).toEqual('e');
         });
 
         it('should return the current character', () => {
             var stream = new CharStream('hello');
-            expect(stream.next()).to.eql('h');
-            expect(stream.next()).to.eql('e');
-            expect(stream.next()).to.eql('l');
-            expect(stream.next()).to.eql('l');
-            expect(stream.next()).to.eql('o');
-            expect(stream.next()).to.equal(EOF);
+            expect(stream.next()).toEqual('h');
+            expect(stream.next()).toEqual('e');
+            expect(stream.next()).toEqual('l');
+            expect(stream.next()).toEqual('l');
+            expect(stream.next()).toEqual('o');
+            expect(stream.next()).toEqual(EOF);
         });
 
         it('should update the line info', () => {
             var stream = new CharStream(`hello
             world`);
-            expect(stream.match('hello')).to.be.true;
+            expect(stream.match('hello')).toBeTruthy();
             stream.next();
-            expect(stream.mark()).to.eql({ line: 2, column: 0, index: 6 });
+            expect(stream.mark()).toEqual({ line: 2, column: 0, index: 6 });
         });
     });
 
@@ -79,27 +78,27 @@ describe('CharStream', function() {
         it('should rewind to the marked position', () => {
             var stream = new CharStream('hello'),
                 start = stream.mark();
-            expect(stream.next()).to.eql('h');
-            expect(stream.next()).to.eql('e');
-            expect(stream.next()).to.eql('l');
-            expect(stream.next()).to.eql('l');
-            expect(stream.next()).to.eql('o');
+            expect(stream.next()).toEqual('h');
+            expect(stream.next()).toEqual('e');
+            expect(stream.next()).toEqual('l');
+            expect(stream.next()).toEqual('l');
+            expect(stream.next()).toEqual('o');
             stream.rewind(start);
-            expect(stream.next()).to.eql('h');
+            expect(stream.next()).toEqual('h');
         });
     });
 
     describe('#match', () => {
         it('should match a string', () => {
             var stream = new CharStream('hello');
-            expect(stream.match('he')).to.be.true;
-            expect(stream.match('llo')).to.be.true;
+            expect(stream.match('he')).toBeTruthy();
+            expect(stream.match('llo')).toBeTruthy();
         });
 
         it('should fail if no match', () => {
             var stream = new CharStream('hello');
-            expect(stream.match('hello world')).to.be.false;
-            expect(stream.match('hello')).to.be.true;
+            expect(stream.match('hello world')).toBeFalsy();
+            expect(stream.match('hello')).toBeTruthy();
         });
     });
 });

--- a/packages/melody-compiler/__tests__/CompilerSpec.js
+++ b/packages/melody-compiler/__tests__/CompilerSpec.js
@@ -192,7 +192,7 @@ describe('Compiler', function() {
                 'foo',
                 '_template',
             ]);
-            expect(testScope === fooScope).toEqual(true);
+            expect(testScope === fooScope).toBeTruthy();
         });
     });
 

--- a/packages/melody-compiler/__tests__/LexerSpec.js
+++ b/packages/melody-compiler/__tests__/LexerSpec.js
@@ -13,90 +13,89 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
-import { CharStream, EOF, Lexer, Types } from 'melody-parser';
+import { CharStream, Lexer, Types } from 'melody-parser';
 
 describe('Lexer', () => {
     it('should match text', () => {
         var lexer = new Lexer(new CharStream(' hello world '));
         var token = lexer.next();
-        expect(token.type).to.eql(Types.TEXT);
-        expect(token.text).to.eql(' hello world ');
+        expect(token.type).toEqual(Types.TEXT);
+        expect(token.text).toEqual(' hello world ');
     });
 
     it('should match strings', () => {
         var lexer = new Lexer(new CharStream('{{ "hello world #{foo} " }}'));
         var token = lexer.next();
-        expect(token.type).to.eql(Types.EXPRESSION_START);
+        expect(token.type).toEqual(Types.EXPRESSION_START);
         token = lexer.next();
-        expect(token.type).to.eql(Types.WHITESPACE);
+        expect(token.type).toEqual(Types.WHITESPACE);
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING_START);
+        expect(token.type).toEqual(Types.STRING_START);
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING);
-        expect(token.text).to.eql('hello world ');
+        expect(token.type).toEqual(Types.STRING);
+        expect(token.text).toEqual('hello world ');
         token = lexer.next();
-        expect(token.type).to.eql(Types.INTERPOLATION_START);
+        expect(token.type).toEqual(Types.INTERPOLATION_START);
         token = lexer.next();
-        expect(token.type).to.eql(Types.SYMBOL);
-        expect(token.text).to.eql('foo');
+        expect(token.type).toEqual(Types.SYMBOL);
+        expect(token.text).toEqual('foo');
         token = lexer.next();
-        expect(token.type).to.eql(Types.INTERPOLATION_END);
+        expect(token.type).toEqual(Types.INTERPOLATION_END);
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING);
-        expect(token.text).to.eql(' ');
+        expect(token.type).toEqual(Types.STRING);
+        expect(token.text).toEqual(' ');
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING_END);
+        expect(token.type).toEqual(Types.STRING_END);
         token = lexer.next();
-        expect(token.type).to.eql(Types.WHITESPACE);
+        expect(token.type).toEqual(Types.WHITESPACE);
         token = lexer.next();
-        expect(token.type).to.eql(Types.EXPRESSION_END);
+        expect(token.type).toEqual(Types.EXPRESSION_END);
     });
 
     it('should match strings', () => {
         var lexer = new Lexer(new CharStream('{{ "hello world #{foo}" }}'));
         var token = lexer.next();
-        expect(token.type).to.eql(Types.EXPRESSION_START);
+        expect(token.type).toEqual(Types.EXPRESSION_START);
         token = lexer.next();
-        expect(token.type).to.eql(Types.WHITESPACE);
+        expect(token.type).toEqual(Types.WHITESPACE);
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING_START);
+        expect(token.type).toEqual(Types.STRING_START);
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING);
-        expect(token.text).to.eql('hello world ');
+        expect(token.type).toEqual(Types.STRING);
+        expect(token.text).toEqual('hello world ');
         token = lexer.next();
-        expect(token.type).to.eql(Types.INTERPOLATION_START);
+        expect(token.type).toEqual(Types.INTERPOLATION_START);
         token = lexer.next();
-        expect(token.type).to.eql(Types.SYMBOL);
-        expect(token.text).to.eql('foo');
+        expect(token.type).toEqual(Types.SYMBOL);
+        expect(token.text).toEqual('foo');
         token = lexer.next();
-        expect(token.type).to.eql(Types.INTERPOLATION_END);
+        expect(token.type).toEqual(Types.INTERPOLATION_END);
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING_END);
+        expect(token.type).toEqual(Types.STRING_END);
         token = lexer.next();
-        expect(token.type).to.eql(Types.WHITESPACE);
+        expect(token.type).toEqual(Types.WHITESPACE);
         token = lexer.next();
-        expect(token.type).to.eql(Types.EXPRESSION_END);
+        expect(token.type).toEqual(Types.EXPRESSION_END);
     });
 
     it('should match text 2', () => {
         var lexer = new Lexer(new CharStream('hello {world'));
         var token = lexer.next();
-        expect(token.type).to.eql(Types.TEXT);
-        expect(token.text).to.eql('hello {world');
+        expect(token.type).toEqual(Types.TEXT);
+        expect(token.text).toEqual('hello {world');
     });
 
     it('should match comments', () => {
         var lexer = new Lexer(new CharStream('hello {# cruel #} world')),
             token = lexer.next();
-        expect(token.type).to.eql(Types.TEXT);
-        expect(token.text).to.eql('hello ');
+        expect(token.type).toEqual(Types.TEXT);
+        expect(token.text).toEqual('hello ');
         token = lexer.next();
-        expect(token.text).to.equal('{# cruel #}');
-        expect(token.type).to.equal(Types.COMMENT);
+        expect(token.text).toEqual('{# cruel #}');
+        expect(token.type).toEqual(Types.COMMENT);
         token = lexer.next();
-        expect(token.text).to.equal(' world');
-        expect(token.type).to.equal(Types.TEXT);
+        expect(token.text).toEqual(' world');
+        expect(token.type).toEqual(Types.TEXT);
     });
 
     describe('in expression state', function() {
@@ -105,28 +104,28 @@ describe('Lexer', () => {
                     new CharStream(' hello {{- "test " -}} world')
                 ),
                 token = lexer.next();
-            expect(token.type).to.eql(Types.TEXT);
-            expect(token.text).to.eql(' hello ');
+            expect(token.type).toEqual(Types.TEXT);
+            expect(token.text).toEqual(' hello ');
             token = lexer.next();
-            expect(token.text).to.equal('{{-');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{-');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.type).to.eql(Types.STRING_START);
+            expect(token.type).toEqual(Types.STRING_START);
             token = lexer.next();
-            expect(token.text).to.equal('test ');
-            expect(token.type).to.equal(Types.STRING);
+            expect(token.text).toEqual('test ');
+            expect(token.type).toEqual(Types.STRING);
             token = lexer.next();
-            expect(token.type).to.eql(Types.STRING_END);
+            expect(token.type).toEqual(Types.STRING_END);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('-}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('-}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
             token = lexer.next();
-            expect(token.text).to.equal(' world');
-            expect(token.type).to.equal(Types.TEXT);
+            expect(token.text).toEqual(' world');
+            expect(token.type).toEqual(Types.TEXT);
         });
 
         it('should parse an expression that is a string and contains escaping', () => {
@@ -134,258 +133,258 @@ describe('Lexer', () => {
                     new CharStream("hello {{ 'test\\'n this' }}world")
                 ),
                 token = lexer.next();
-            expect(token.type).to.eql(Types.TEXT);
-            expect(token.text).to.eql('hello ');
-            expect(token.pos.column).to.equal(0);
+            expect(token.type).toEqual(Types.TEXT);
+            expect(token.text).toEqual('hello ');
+            expect(token.pos.column).toEqual(0);
             token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
-            expect(token.pos.column).to.equal(6);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
+            expect(token.pos.column).toEqual(6);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.type).to.eql(Types.STRING_START);
+            expect(token.type).toEqual(Types.STRING_START);
             token = lexer.next();
-            expect(token.text).to.equal("test'n this");
-            expect(token.type).to.equal(Types.STRING);
+            expect(token.text).toEqual("test'n this");
+            expect(token.type).toEqual(Types.STRING);
             token = lexer.next();
-            expect(token.type).to.eql(Types.STRING_END);
+            expect(token.type).toEqual(Types.STRING_END);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
             token = lexer.next();
-            expect(token.text).to.equal('world');
-            expect(token.type).to.equal(Types.TEXT);
+            expect(token.text).toEqual('world');
+            expect(token.type).toEqual(Types.TEXT);
         });
 
         it('should parse an expression that is a integer', () => {
             var lexer = new Lexer(new CharStream('{{ 100 }}')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('100');
-            expect(token.type).to.equal(Types.NUMBER);
+            expect(token.text).toEqual('100');
+            expect(token.type).toEqual(Types.NUMBER);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
         });
 
         it('should parse an expression that is a float', () => {
             var lexer = new Lexer(new CharStream('{{ 1.01 }}')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('1.01');
-            expect(token.type).to.equal(Types.NUMBER);
+            expect(token.text).toEqual('1.01');
+            expect(token.type).toEqual(Types.NUMBER);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
         });
 
         it('should parse an expression that is true', () => {
             var lexer = new Lexer(new CharStream('{{ true }}')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('true');
-            expect(token.type).to.equal(Types.TRUE);
+            expect(token.text).toEqual('true');
+            expect(token.type).toEqual(Types.TRUE);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
         });
 
         it('should parse an expression that is false', () => {
             var lexer = new Lexer(new CharStream('{{ false }}')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('false');
-            expect(token.type).to.equal(Types.FALSE);
+            expect(token.text).toEqual('false');
+            expect(token.type).toEqual(Types.FALSE);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
         });
 
         it('should parse an expression that is null', () => {
             var lexer = new Lexer(new CharStream('{{null}}')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('null');
-            expect(token.type).to.equal(Types.NULL);
+            expect(token.text).toEqual('null');
+            expect(token.type).toEqual(Types.NULL);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
         });
 
         it('should parse an expression that is (', () => {
             var lexer = new Lexer(new CharStream('{{(')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('(');
-            expect(token.type).to.equal(Types.LPAREN);
+            expect(token.text).toEqual('(');
+            expect(token.type).toEqual(Types.LPAREN);
         });
 
         it('should parse an expression that is )', () => {
             var lexer = new Lexer(new CharStream('{{)')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal(')');
-            expect(token.type).to.equal(Types.RPAREN);
+            expect(token.text).toEqual(')');
+            expect(token.type).toEqual(Types.RPAREN);
         });
 
         it('should parse an expression that is [', () => {
             var lexer = new Lexer(new CharStream('{{[')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('[');
-            expect(token.type).to.equal(Types.LBRACE);
+            expect(token.text).toEqual('[');
+            expect(token.type).toEqual(Types.LBRACE);
         });
 
         it('should parse an expression that is ]', () => {
             var lexer = new Lexer(new CharStream('{{]')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal(']');
-            expect(token.type).to.equal(Types.RBRACE);
+            expect(token.text).toEqual(']');
+            expect(token.type).toEqual(Types.RBRACE);
         });
 
         it('should parse an expression that is }', () => {
             var lexer = new Lexer(new CharStream('{{}')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('}');
-            expect(token.type).to.equal(Types.RBRACKET);
+            expect(token.text).toEqual('}');
+            expect(token.type).toEqual(Types.RBRACKET);
         });
 
         it('should parse an expression that is {', () => {
             var lexer = new Lexer(new CharStream('{{{')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('{');
-            expect(token.type).to.equal(Types.LBRACKET);
+            expect(token.text).toEqual('{');
+            expect(token.type).toEqual(Types.LBRACKET);
         });
 
         it('should parse an expression that is (', () => {
             var lexer = new Lexer(new CharStream('{{(')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('(');
-            expect(token.type).to.equal(Types.LPAREN);
+            expect(token.text).toEqual('(');
+            expect(token.type).toEqual(Types.LPAREN);
         });
 
         it('should parse an expression that is )', () => {
             var lexer = new Lexer(new CharStream('{{)')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal(')');
-            expect(token.type).to.equal(Types.RPAREN);
+            expect(token.text).toEqual(')');
+            expect(token.type).toEqual(Types.RPAREN);
         });
 
         it('should parse an expression that is :', () => {
             var lexer = new Lexer(new CharStream('{{:')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal(':');
-            expect(token.type).to.equal(Types.COLON);
+            expect(token.text).toEqual(':');
+            expect(token.type).toEqual(Types.COLON);
         });
 
         it('should parse an expression that is .', () => {
             var lexer = new Lexer(new CharStream('{{.')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('.');
-            expect(token.type).to.equal(Types.DOT);
+            expect(token.text).toEqual('.');
+            expect(token.type).toEqual(Types.DOT);
         });
 
         it('should parse an expression that is (', () => {
             var lexer = new Lexer(new CharStream('{{(')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('(');
-            expect(token.type).to.equal(Types.LPAREN);
+            expect(token.text).toEqual('(');
+            expect(token.type).toEqual(Types.LPAREN);
         });
 
         it('should parse an expression that is ,', () => {
             var lexer = new Lexer(new CharStream('{{,')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal(',');
-            expect(token.type).to.equal(Types.COMMA);
+            expect(token.text).toEqual(',');
+            expect(token.type).toEqual(Types.COMMA);
         });
 
         it('should parse an expression that is (', () => {
             var lexer = new Lexer(new CharStream('{{(')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('(');
-            expect(token.type).to.equal(Types.LPAREN);
+            expect(token.text).toEqual('(');
+            expect(token.type).toEqual(Types.LPAREN);
         });
 
         it('should parse an expression that is a symbol', () => {
             var lexer = new Lexer(new CharStream('{{ foo }}')),
                 token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('foo');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('foo');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
         });
 
         it('should match an operator by length', () => {
@@ -393,28 +392,28 @@ describe('Lexer', () => {
                 token;
             lexer.addOperators('in', 'in by');
             token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('foo');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('foo');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('in by');
-            expect(token.type).to.equal(Types.OPERATOR);
+            expect(token.text).toEqual('in by');
+            expect(token.type).toEqual(Types.OPERATOR);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('bar');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('bar');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
         });
 
         it('should match a not expression', () => {
@@ -422,23 +421,23 @@ describe('Lexer', () => {
                 token;
             lexer.addOperators('not', 'not in');
             token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.equal(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('not');
-            expect(token.type).to.equal(Types.OPERATOR);
+            expect(token.text).toEqual('not');
+            expect(token.type).toEqual(Types.OPERATOR);
             token = lexer.next();
-            expect(token.type).to.equal(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('invalid');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('invalid');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.equal(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
         });
 
         //it('should match a test by length', () => {
@@ -447,23 +446,23 @@ describe('Lexer', () => {
         //    lexer.addOperators('is');
         //    lexer.addTests('divisible', 'divisible by');
         //    token = lexer.next();
-        //    expect(token.text).to.equal('{{');
-        //    expect(token.type).to.equal(Types.EXPRESSION_START);
+        //    expect(token.text).toEqual('{{');
+        //    expect(token.type).toEqual(Types.EXPRESSION_START);
         //    token = lexer.next();
-        //    expect(token.text).to.equal("foo");
-        //    expect(token.type).to.equal(Types.SYMBOL);
+        //    expect(token.text).toEqual("foo");
+        //    expect(token.type).toEqual(Types.SYMBOL);
         //    token = lexer.next();
-        //    expect(token.text).to.equal("is");
-        //    expect(token.type).to.equal(Types.OPERATOR);
+        //    expect(token.text).toEqual("is");
+        //    expect(token.type).toEqual(Types.OPERATOR);
         //    token = lexer.next();
-        //    expect(token.text).to.equal("divisible by");
-        //    expect(token.type).to.equal(Types.TEST);
+        //    expect(token.text).toEqual("divisible by");
+        //    expect(token.type).toEqual(Types.TEST);
         //    token = lexer.next();
-        //    expect(token.text).to.equal("bar");
-        //    expect(token.type).to.equal(Types.SYMBOL);
+        //    expect(token.text).toEqual("bar");
+        //    expect(token.type).toEqual(Types.SYMBOL);
         //    token = lexer.next();
-        //    expect(token.text).to.equal('}}');
-        //    expect(token.type).to.equal(Types.EXPRESSION_END);
+        //    expect(token.text).toEqual('}}');
+        //    expect(token.type).toEqual(Types.EXPRESSION_END);
         //});
     });
 
@@ -472,18 +471,18 @@ describe('Lexer', () => {
             var lexer = new Lexer(new CharStream('{% if %}')),
                 token;
             token = lexer.next();
-            expect(token.text).to.equal('{%');
-            expect(token.type).to.equal(Types.TAG_START);
+            expect(token.text).toEqual('{%');
+            expect(token.type).toEqual(Types.TAG_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('if');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('if');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('%}');
-            expect(token.type).to.equal(Types.TAG_END);
+            expect(token.text).toEqual('%}');
+            expect(token.type).toEqual(Types.TAG_END);
         });
 
         it('should match an extends tag', function() {
@@ -493,27 +492,27 @@ describe('Lexer', () => {
                 token;
             lexer.addOperators('+');
             token = lexer.next();
-            expect(token.text).to.equal('{%');
-            expect(token.type).to.equal(Types.TAG_START);
+            expect(token.text).toEqual('{%');
+            expect(token.type).toEqual(Types.TAG_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('extends');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('extends');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.type).to.eql(Types.STRING_START);
+            expect(token.type).toEqual(Types.STRING_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.STRING);
-            expect(token.text).to.equal('foo.html.twig');
+            expect(token.type).toEqual(Types.STRING);
+            expect(token.text).toEqual('foo.html.twig');
             token = lexer.next();
-            expect(token.type).to.eql(Types.STRING_END);
+            expect(token.type).toEqual(Types.STRING_END);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('%}');
-            expect(token.type).to.equal(Types.TAG_END);
+            expect(token.text).toEqual('%}');
+            expect(token.type).toEqual(Types.TAG_END);
         });
     });
 
@@ -522,29 +521,29 @@ describe('Lexer', () => {
             var lexer = new Lexer(new CharStream('<div>Test</div>')),
                 token;
             token = lexer.next();
-            expect(token.type).to.equal(Types.ELEMENT_START);
-            expect(token.text).to.equal('<');
+            expect(token.type).toEqual(Types.ELEMENT_START);
+            expect(token.text).toEqual('<');
             token = lexer.next();
-            expect(token.text).to.equal('div');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('div');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('>');
-            expect(token.type).to.equal(Types.ELEMENT_END);
+            expect(token.text).toEqual('>');
+            expect(token.type).toEqual(Types.ELEMENT_END);
             token = lexer.next();
-            expect(token.text).to.equal('Test');
-            expect(token.type).to.equal(Types.TEXT);
+            expect(token.text).toEqual('Test');
+            expect(token.type).toEqual(Types.TEXT);
             token = lexer.next();
-            expect(token.type).to.equal(Types.ELEMENT_START);
-            expect(token.text).to.equal('<');
+            expect(token.type).toEqual(Types.ELEMENT_START);
+            expect(token.text).toEqual('<');
             token = lexer.next();
-            expect(token.type).to.equal(Types.SLASH);
-            expect(token.text).to.equal('/');
+            expect(token.type).toEqual(Types.SLASH);
+            expect(token.text).toEqual('/');
             token = lexer.next();
-            expect(token.text).to.equal('div');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('div');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('>');
-            expect(token.type).to.equal(Types.ELEMENT_END);
+            expect(token.text).toEqual('>');
+            expect(token.type).toEqual(Types.ELEMENT_END);
         });
 
         it('should match simple HTML attributes', () => {
@@ -553,46 +552,46 @@ describe('Lexer', () => {
                 ),
                 token;
             token = lexer.next();
-            expect(token.type).to.equal(Types.ELEMENT_START);
-            expect(token.text).to.equal('<');
+            expect(token.type).toEqual(Types.ELEMENT_START);
+            expect(token.text).toEqual('<');
             token = lexer.next();
-            expect(token.text).to.equal('div');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('div');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('class');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('class');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('=');
-            expect(token.type).to.equal(Types.ASSIGNMENT);
+            expect(token.text).toEqual('=');
+            expect(token.type).toEqual(Types.ASSIGNMENT);
             token = lexer.next();
-            expect(token.text).to.equal('"');
-            expect(token.type).to.equal(Types.STRING_START);
+            expect(token.text).toEqual('"');
+            expect(token.type).toEqual(Types.STRING_START);
             token = lexer.next();
-            expect(token.text).to.equal('foo');
-            expect(token.type).to.equal(Types.STRING);
+            expect(token.text).toEqual('foo');
+            expect(token.type).toEqual(Types.STRING);
             token = lexer.next();
-            expect(token.text).to.equal('"');
-            expect(token.type).to.equal(Types.STRING_END);
+            expect(token.text).toEqual('"');
+            expect(token.type).toEqual(Types.STRING_END);
             token = lexer.next();
-            expect(token.text).to.equal('>');
-            expect(token.type).to.equal(Types.ELEMENT_END);
+            expect(token.text).toEqual('>');
+            expect(token.type).toEqual(Types.ELEMENT_END);
             token = lexer.next();
-            expect(token.text).to.equal('Test');
-            expect(token.type).to.equal(Types.TEXT);
+            expect(token.text).toEqual('Test');
+            expect(token.type).toEqual(Types.TEXT);
             token = lexer.next();
-            expect(token.type).to.equal(Types.ELEMENT_START);
-            expect(token.text).to.equal('<');
+            expect(token.type).toEqual(Types.ELEMENT_START);
+            expect(token.text).toEqual('<');
             token = lexer.next();
-            expect(token.type).to.equal(Types.SLASH);
-            expect(token.text).to.equal('/');
+            expect(token.type).toEqual(Types.SLASH);
+            expect(token.text).toEqual('/');
             token = lexer.next();
-            expect(token.text).to.equal('div');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('div');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('>');
-            expect(token.type).to.equal(Types.ELEMENT_END);
+            expect(token.text).toEqual('>');
+            expect(token.type).toEqual(Types.ELEMENT_END);
         });
 
         it('should match simple HTML attributes with expression value', () => {
@@ -601,52 +600,52 @@ describe('Lexer', () => {
                 ),
                 token;
             token = lexer.next();
-            expect(token.type).to.equal(Types.ELEMENT_START);
-            expect(token.text).to.equal('<');
+            expect(token.type).toEqual(Types.ELEMENT_START);
+            expect(token.text).toEqual('<');
             token = lexer.next();
-            expect(token.text).to.equal('div');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('div');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('class');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('class');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('=');
-            expect(token.type).to.equal(Types.ASSIGNMENT);
+            expect(token.text).toEqual('=');
+            expect(token.type).toEqual(Types.ASSIGNMENT);
             token = lexer.next();
-            expect(token.text).to.equal('"');
-            expect(token.type).to.equal(Types.STRING_START);
+            expect(token.text).toEqual('"');
+            expect(token.type).toEqual(Types.STRING_START);
             token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('name');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('name');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
             token = lexer.next();
-            expect(token.text).to.equal('"');
-            expect(token.type).to.equal(Types.STRING_END);
+            expect(token.text).toEqual('"');
+            expect(token.type).toEqual(Types.STRING_END);
             token = lexer.next();
-            expect(token.text).to.equal('>');
-            expect(token.type).to.equal(Types.ELEMENT_END);
+            expect(token.text).toEqual('>');
+            expect(token.type).toEqual(Types.ELEMENT_END);
             token = lexer.next();
-            expect(token.text).to.equal('Test');
-            expect(token.type).to.equal(Types.TEXT);
+            expect(token.text).toEqual('Test');
+            expect(token.type).toEqual(Types.TEXT);
             token = lexer.next();
-            expect(token.type).to.equal(Types.ELEMENT_START);
-            expect(token.text).to.equal('<');
+            expect(token.type).toEqual(Types.ELEMENT_START);
+            expect(token.text).toEqual('<');
             token = lexer.next();
-            expect(token.type).to.equal(Types.SLASH);
-            expect(token.text).to.equal('/');
+            expect(token.type).toEqual(Types.SLASH);
+            expect(token.text).toEqual('/');
             token = lexer.next();
-            expect(token.text).to.equal('div');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('div');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('>');
-            expect(token.type).to.equal(Types.ELEMENT_END);
+            expect(token.text).toEqual('>');
+            expect(token.type).toEqual(Types.ELEMENT_END);
         });
 
         it('should match HTML attributes with mixed values', () => {
@@ -655,58 +654,58 @@ describe('Lexer', () => {
                 ),
                 token;
             token = lexer.next();
-            expect(token.type).to.equal(Types.ELEMENT_START);
-            expect(token.text).to.equal('<');
+            expect(token.type).toEqual(Types.ELEMENT_START);
+            expect(token.text).toEqual('<');
             token = lexer.next();
-            expect(token.text).to.equal('div');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('div');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.text).to.equal('class');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('class');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('=');
-            expect(token.type).to.equal(Types.ASSIGNMENT);
+            expect(token.text).toEqual('=');
+            expect(token.type).toEqual(Types.ASSIGNMENT);
             token = lexer.next();
-            expect(token.text).to.equal('"');
-            expect(token.type).to.equal(Types.STRING_START);
+            expect(token.text).toEqual('"');
+            expect(token.type).toEqual(Types.STRING_START);
             token = lexer.next();
-            expect(token.text).to.equal('test-');
-            expect(token.type).to.equal(Types.STRING);
+            expect(token.text).toEqual('test-');
+            expect(token.type).toEqual(Types.STRING);
             token = lexer.next();
-            expect(token.text).to.equal('{{');
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.text).toEqual('{{');
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.text).to.equal('name');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('name');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('}}');
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.text).toEqual('}}');
+            expect(token.type).toEqual(Types.EXPRESSION_END);
             token = lexer.next();
-            expect(token.text).to.equal(' foo');
-            expect(token.type).to.equal(Types.STRING);
+            expect(token.text).toEqual(' foo');
+            expect(token.type).toEqual(Types.STRING);
             token = lexer.next();
-            expect(token.text).to.equal('"');
-            expect(token.type).to.equal(Types.STRING_END);
+            expect(token.text).toEqual('"');
+            expect(token.type).toEqual(Types.STRING_END);
             token = lexer.next();
-            expect(token.text).to.equal('>');
-            expect(token.type).to.equal(Types.ELEMENT_END);
+            expect(token.text).toEqual('>');
+            expect(token.type).toEqual(Types.ELEMENT_END);
             token = lexer.next();
-            expect(token.text).to.equal('Test');
-            expect(token.type).to.equal(Types.TEXT);
+            expect(token.text).toEqual('Test');
+            expect(token.type).toEqual(Types.TEXT);
             token = lexer.next();
-            expect(token.type).to.equal(Types.ELEMENT_START);
-            expect(token.text).to.equal('<');
+            expect(token.type).toEqual(Types.ELEMENT_START);
+            expect(token.text).toEqual('<');
             token = lexer.next();
-            expect(token.type).to.equal(Types.SLASH);
-            expect(token.text).to.equal('/');
+            expect(token.type).toEqual(Types.SLASH);
+            expect(token.text).toEqual('/');
             token = lexer.next();
-            expect(token.text).to.equal('div');
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.text).toEqual('div');
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.text).to.equal('>');
-            expect(token.type).to.equal(Types.ELEMENT_END);
+            expect(token.text).toEqual('>');
+            expect(token.type).toEqual(Types.ELEMENT_END);
         });
 
         it('should keep quotes in interpolation', () => {
@@ -717,39 +716,39 @@ describe('Lexer', () => {
                 ),
                 token;
             token = lexer.next();
-            expect(token.type).to.equal(Types.EXPRESSION_START);
+            expect(token.type).toEqual(Types.EXPRESSION_START);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.type).to.equal(Types.QUESTION_MARK);
+            expect(token.type).toEqual(Types.QUESTION_MARK);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.type).to.equal(Types.STRING_START);
+            expect(token.type).toEqual(Types.STRING_START);
             token = lexer.next();
-            expect(token.type).to.equal(Types.STRING);
-            expect(token.text).to.equal('class="');
+            expect(token.type).toEqual(Types.STRING);
+            expect(token.text).toEqual('class="');
             token = lexer.next();
-            expect(token.type).to.equal(Types.INTERPOLATION_START);
+            expect(token.type).toEqual(Types.INTERPOLATION_START);
             token = lexer.next();
-            expect(token.type).to.equal(Types.SYMBOL);
+            expect(token.type).toEqual(Types.SYMBOL);
             token = lexer.next();
-            expect(token.type).to.equal(Types.INTERPOLATION_END);
+            expect(token.type).toEqual(Types.INTERPOLATION_END);
             token = lexer.next();
-            expect(token.type).to.equal(Types.STRING);
-            expect(token.text).to.equal('" data-even');
+            expect(token.type).toEqual(Types.STRING);
+            expect(token.text).toEqual('" data-even');
             token = lexer.next();
-            expect(token.type).to.equal(Types.STRING_END);
+            expect(token.type).toEqual(Types.STRING_END);
             token = lexer.next();
-            expect(token.type).to.eql(Types.WHITESPACE);
+            expect(token.type).toEqual(Types.WHITESPACE);
             token = lexer.next();
-            expect(token.type).to.equal(Types.EXPRESSION_END);
+            expect(token.type).toEqual(Types.EXPRESSION_END);
             token = lexer.next();
-            expect(token.type).to.equal(Types.EOF);
+            expect(token.type).toEqual(Types.EOF);
         });
     });
 });

--- a/packages/melody-compiler/__tests__/TokenStreamSpec.js
+++ b/packages/melody-compiler/__tests__/TokenStreamSpec.js
@@ -13,25 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
-import { CharStream, EOF, Lexer, TokenStream, Types } from 'melody-parser';
+import { CharStream, Lexer, TokenStream, Types } from 'melody-parser';
 
 describe('TokenStream', function() {
     it('should parse an expression', function() {
         let stream = createTokenStream('Hello {{ "Patrick" }}');
-        expect(stream.test(Types.TEXT, 'Hello ')).to.be.true;
+        expect(stream.test(Types.TEXT, 'Hello ')).toBeTruthy();
         stream.next();
-        expect(stream.test(Types.EXPRESSION_START)).to.be.true;
+        expect(stream.test(Types.EXPRESSION_START)).toBeTruthy();
         stream.next();
-        expect(stream.test(Types.STRING_START)).to.be.true;
+        expect(stream.test(Types.STRING_START)).toBeTruthy();
         stream.next();
-        expect(stream.test(Types.STRING, 'Patrick')).to.be.true;
+        expect(stream.test(Types.STRING, 'Patrick')).toBeTruthy();
         stream.next();
-        expect(stream.test(Types.STRING_END)).to.be.true;
+        expect(stream.test(Types.STRING_END)).toBeTruthy();
         stream.next();
-        expect(stream.test(Types.EXPRESSION_END)).to.be.true;
+        expect(stream.test(Types.EXPRESSION_END)).toBeTruthy();
         stream.next();
-        expect(stream.test(Types.TEXT)).to.be.false;
+        expect(stream.test(Types.TEXT)).toBeFalsy();
         stream.next();
     });
 
@@ -39,21 +38,21 @@ describe('TokenStream', function() {
         var lexer = createTokenStream('{% extends "foo.html.twig" %}'),
             token;
         token = lexer.next();
-        expect(token.text).to.equal('{%');
-        expect(token.type).to.equal(Types.TAG_START);
+        expect(token.text).toEqual('{%');
+        expect(token.type).toEqual(Types.TAG_START);
         token = lexer.next();
-        expect(token.text).to.equal('extends');
-        expect(token.type).to.equal(Types.SYMBOL);
+        expect(token.text).toEqual('extends');
+        expect(token.type).toEqual(Types.SYMBOL);
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING_START);
+        expect(token.type).toEqual(Types.STRING_START);
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING);
-        expect(token.text).to.equal('foo.html.twig');
+        expect(token.type).toEqual(Types.STRING);
+        expect(token.text).toEqual('foo.html.twig');
         token = lexer.next();
-        expect(token.type).to.eql(Types.STRING_END);
+        expect(token.type).toEqual(Types.STRING_END);
         token = lexer.next();
-        expect(token.text).to.equal('%}');
-        expect(token.type).to.equal(Types.TAG_END);
+        expect(token.text).toEqual('%}');
+        expect(token.type).toEqual(Types.TAG_END);
     });
 });
 

--- a/packages/melody-compiler/__tests__/TraversalSpec.js
+++ b/packages/melody-compiler/__tests__/TraversalSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 import { parse } from 'melody-parser';
 import { traverse, merge } from 'melody-traverse';
 import * as n from 'melody-types';
@@ -29,10 +28,10 @@ describe('Traversal', function() {
                 BinaryConcatExpression(path) {
                     switch (concats) {
                         case 0:
-                            expect(path.node.right.value).to.equal(' ');
+                            expect(path.node.right.value).toEqual(' ');
                             break;
                         case 1:
-                            expect(path.node.right.name).to.equal('bar');
+                            expect(path.node.right.name).toEqual('bar');
                             break;
                     }
                     concats++;
@@ -40,24 +39,24 @@ describe('Traversal', function() {
                 StringLiteral(path) {
                     switch (stringLiterals) {
                         case 0:
-                            expect(path.node.value).to.equal(' foo ');
+                            expect(path.node.value).toEqual(' foo ');
                             break;
                         case 1:
-                            expect(path.node.value).to.equal(' ');
+                            expect(path.node.value).toEqual(' ');
                             break;
                     }
                     stringLiterals++;
                 },
                 Identifier(path) {
                     if (identifiers === 0) {
-                        expect(path.node.name).to.equal('bar');
+                        expect(path.node.name).toEqual('bar');
                     }
                     identifiers++;
                 },
             });
-            expect(concats).to.equal(2);
-            expect(stringLiterals).to.equal(2);
-            expect(identifiers).to.equal(1);
+            expect(concats).toEqual(2);
+            expect(stringLiterals).toEqual(2);
+            expect(identifiers).toEqual(1);
         });
     });
 
@@ -71,10 +70,10 @@ describe('Traversal', function() {
                     }
                 },
             });
-            expect(node.expressions[0].value.left.left.right.name).to.equal(
-                'foo',
+            expect(node.expressions[0].value.left.left.right.name).toEqual(
+                'foo'
             );
-            expect(node.expressions[0].value.right.name).to.equal('baz');
+            expect(node.expressions[0].value.right.name).toEqual('baz');
         });
     });
 
@@ -96,13 +95,13 @@ describe('Traversal', function() {
             };
             const visitor = merge(counter, replacer);
             traverse(node, visitor);
-            expect(node.expressions[0].value.left.left.right.name).to.equal(
-                'foo',
+            expect(node.expressions[0].value.left.left.right.name).toEqual(
+                'foo'
             );
-            expect(node.expressions[0].value.right.name).to.equal('baz');
-            expect(count.bar).to.equal(1);
-            expect(count.baz).to.equal(1);
-            expect(count.foo).to.equal(1);
+            expect(node.expressions[0].value.right.name).toEqual('baz');
+            expect(count.bar).toEqual(1);
+            expect(count.baz).toEqual(1);
+            expect(count.foo).toEqual(1);
         });
     });
 });

--- a/packages/melody-component/__tests__/ComponentSpec.js
+++ b/packages/melody-component/__tests__/ComponentSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
 
 import { createComponent, RECEIVE_PROPS, render } from '../src';
 import {
@@ -45,12 +44,12 @@ describe('Component', function() {
         });
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div>hello</div>');
+        expect(mounted).toEqual(1);
 
         render(root, MyComponent, { text: 'test' });
-        assert.equal(root.outerHTML, '<div>test</div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div>test</div>');
+        expect(mounted).toEqual(1);
     });
 
     it('mixins can be applied with a curried function', function() {
@@ -70,12 +69,12 @@ describe('Component', function() {
         });
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div>hello</div>');
+        expect(mounted).toEqual(1);
 
         render(root, MyComponent, { text: 'test' });
-        assert.equal(root.outerHTML, '<div>test</div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div>test</div>');
+        expect(mounted).toEqual(1);
     });
 
     it('mixins can be applied arbitrarily often with a curried function', function() {
@@ -97,20 +96,21 @@ describe('Component', function() {
         });
 
         const MyComponent = createComponent(template)(countMounting(0))(
-            countMounting(1),
+            countMounting(1)
         )(countMounting(2));
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
-        assert.equal(mounted[0], 1);
-        assert.equal(mounted[1], 1);
-        assert.equal(mounted[2], 1);
+
+        expect(root.outerHTML).toEqual('<div>hello</div>');
+        expect(mounted[0]).toEqual(1);
+        expect(mounted[1]).toEqual(1);
+        expect(mounted[2]).toEqual(1);
 
         render(root, MyComponent, { text: 'test' });
-        assert.equal(root.outerHTML, '<div>test</div>');
-        assert.equal(mounted[0], 1);
-        assert.equal(mounted[1], 1);
-        assert.equal(mounted[2], 1);
+        expect(root.outerHTML).toEqual('<div>test</div>');
+        expect(mounted[0]).toEqual(1);
+        expect(mounted[1]).toEqual(1);
+        expect(mounted[2]).toEqual(1);
     });
 
     it('should trigger componentWillUnmount when a Component is removed', function() {
@@ -149,8 +149,11 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.innerHTML, '<div><p>hello</p><span>foo</span></div>');
-        assert.equal(unmounted, 0);
+
+        expect(root.innerHTML).toEqual(
+            '<div><p>hello</p><span>foo</span></div>'
+        );
+        expect(unmounted).toEqual(0);
 
         patchOuter(root, renderTemplate, { comp: false });
         flush({
@@ -159,8 +162,9 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.innerHTML, '');
-        assert.equal(unmounted, 1);
+
+        expect(root.innerHTML).toEqual('');
+        expect(unmounted).toEqual(1);
     });
 
     it('should trigger componentWillUnmount when a Component is removed within an element', function() {
@@ -196,8 +200,9 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.innerHTML, '<div><div>hello</div></div>');
-        assert.equal(unmounted, 0);
+
+        expect(root.innerHTML).toEqual('<div><div>hello</div></div>');
+        expect(unmounted).toEqual(0);
 
         patchOuter(root, renderTemplate, { comp: false });
         flush({
@@ -206,12 +211,12 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.innerHTML, '');
-        assert.equal(unmounted, 1);
+
+        expect(root.innerHTML).toEqual('');
+        expect(unmounted).toEqual(1);
     });
 
     it('should trigger componentWillUnmount for child components when a Component is removed', function() {
-        let MyComponent;
         const template = {
             render(_context) {
                 elementOpen('div', null, null);
@@ -227,7 +232,7 @@ describe('Component', function() {
         };
         const root = document.createElement('div');
         let unmounted = 0;
-        MyComponent = createComponent(template)({
+        const MyComponent = createComponent(template)({
             componentDidMount() {
                 unmounted++;
             },
@@ -251,8 +256,9 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.innerHTML, '<div>hello<div>world</div></div>');
-        assert.equal(unmounted, 2);
+
+        expect(root.innerHTML).toEqual('<div>hello<div>world</div></div>');
+        expect(unmounted).toEqual(2);
 
         patchOuter(root, renderTemplate, { comp: false });
         flush({
@@ -261,8 +267,9 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.innerHTML, '');
-        assert.equal(unmounted, 0);
+
+        expect(root.innerHTML).toEqual('');
+        expect(unmounted).toEqual(0);
     });
 
     it('should trigger componentWillUnmount for deep nested child components when a Component is removed', function() {
@@ -315,10 +322,10 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.innerHTML, '<div><div><div></div></div></div>');
-        assert.equal(unmounted.inner, 1);
-        assert.equal(unmounted.middle, 1);
-        assert.equal(unmounted.outer, 1);
+        expect(root.innerHTML).toEqual('<div><div><div></div></div></div>');
+        expect(unmounted.inner).toEqual(1);
+        expect(unmounted.middle).toEqual(1);
+        expect(unmounted.outer).toEqual(1);
 
         patchOuter(root, renderTemplate, { comp: false });
         flush({
@@ -327,10 +334,10 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.innerHTML, '');
-        assert.equal(unmounted.inner, 0);
-        assert.equal(unmounted.middle, 0);
-        assert.equal(unmounted.outer, 0);
+        expect(root.innerHTML).toEqual('');
+        expect(unmounted.inner).toEqual(0);
+        expect(unmounted.middle).toEqual(0);
+        expect(unmounted.outer).toEqual(0);
     });
 
     it('should trigger componentWillUnmount for deep nested child components when a Component is removed', function() {
@@ -379,16 +386,16 @@ describe('Component', function() {
         })({ name: 'outer' }, CountInstances);
 
         render(root, OuterComponent, { comp: true });
-        assert.equal(root.innerHTML, '<div><div><div></div></div></div>');
-        assert.equal(unmounted.inner, 1);
-        assert.equal(unmounted.middle, 1);
-        assert.equal(unmounted.outer, 1);
+        expect(root.innerHTML).toEqual('<div><div><div></div></div></div>');
+        expect(unmounted.inner).toEqual(1);
+        expect(unmounted.middle).toEqual(1);
+        expect(unmounted.outer).toEqual(1);
 
         render(root, OuterComponent, { comp: false });
-        assert.equal(root.innerHTML, '');
-        assert.equal(unmounted.inner, 0);
-        assert.equal(unmounted.middle, 0);
-        assert.equal(unmounted.outer, 1);
+        expect(root.innerHTML).toEqual('');
+        expect(unmounted.inner).toEqual(0);
+        expect(unmounted.middle).toEqual(0);
+        expect(unmounted.outer).toEqual(1);
     });
 
     it('should register refs', function() {
@@ -403,27 +410,27 @@ describe('Component', function() {
         const root = document.createElement('div');
         const MyComponent = createComponent(template, undefined, {
             componentDidMount() {
-                assert(this.refs.fun != null, 'fun ref should exist');
+                expect(this.refs.fun).not.toBeNull();
                 this.refs.fun.innerHTML = 'test';
             },
 
             componentDidUpdate(prevProps, prevState) {
                 expect(this.el.outerHTML).toEqual('<div>world</div>');
                 this.refs.fun.innerHTML = 'fun!';
-                assert(prevState !== this.state);
+                expect(prevState).not.toEqual(this.state);
                 expect(prevProps).not.toEqual(this.props);
-                assert(prevState.text === 'hello');
-                assert(prevProps.text === 'hello');
-                assert.equal(this.state.text, 'world');
-                assert.equal(this.props.text, 'world');
+                expect(prevState.text).toEqual('hello');
+                expect(prevProps.text).toEqual('hello');
+                expect(this.state.text).toEqual('world');
+                expect(this.props.text).toEqual('world');
             },
         });
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>test</div>');
+        expect(root.outerHTML).toEqual('<div>test</div>');
 
         render(root, MyComponent, { text: 'world' });
-        assert.equal(root.outerHTML, '<div>fun!</div>');
+        expect(root.outerHTML).toEqual('<div>fun!</div>');
     });
 
     it('should register refs for the current element', function() {
@@ -438,25 +445,26 @@ describe('Component', function() {
         const root = document.createElement('div');
         const MyComponent = createComponent(template, undefined, {
             componentDidMount() {
-                assert(this.refs.fun != null, 'fun ref should exist');
+                // 'fun ref should exist'
+                expect(this.refs.fun).not.toBeNull();
                 this.refs.fun.innerHTML = 'test';
             },
         });
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>test</div>');
+        expect(root.outerHTML).toEqual('<div>test</div>');
     });
 
     it('should throw when registering a ref outside of a component', function() {
         const root = document.createElement('div');
         const statics = ['ref', ref('test')];
-        assert.throws(() => {
+        expect(() => {
             patch(root, () => {
                 elementOpen('div', null, statics);
                 text('test');
                 elementClose('div');
             });
-        }, 'ref() must be used within a component');
+        }).toThrowError(new Error('ref() must be used within a component'));
     });
 
     it('should trigger componentDidMount once even for nested components', function() {
@@ -472,7 +480,8 @@ describe('Component', function() {
         const MyComponent = createComponent(childTemplate, undefined, {
             componentDidMount() {
                 mounted++;
-                assert(this.el != null, 'Element should exists');
+                // 'Element should exists'
+                expect(this.el).not.toBeNull();
             },
         });
 
@@ -487,12 +496,12 @@ describe('Component', function() {
 
         const root = document.createElement('div');
         render(root, MyParentComponent, { childProps: { text: 'hello' } });
-        assert.equal(root.outerHTML, '<div><div>hello</div></div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div><div>hello</div></div>');
+        expect(mounted).toEqual(1);
 
         render(root, MyParentComponent, { childProps: { text: 'test' } });
-        assert.equal(root.outerHTML, '<div><div>test</div></div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div><div>test</div></div>');
+        expect(mounted).toEqual(1);
     });
 
     it('should have an element during componentDidMount', function() {
@@ -508,12 +517,12 @@ describe('Component', function() {
         const MyComponent = createComponent(template, undefined, {
             componentDidMount() {
                 mounted++;
-                assert.equal(this.el, root, 'Element should be set');
+                expect(this.el).toEqual(root);
             },
         });
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(mounted, 1);
+        expect(mounted).toEqual(1);
     });
 
     it('should not render if data is unchanged', function() {
@@ -528,10 +537,10 @@ describe('Component', function() {
         const MyComponent = createComponent(template);
         const props = { text: 'hello' };
         render(root, MyComponent, props);
-        assert.equal(root.innerHTML, 'hello');
+        expect(root.innerHTML).toEqual('hello');
         props.text = 'world';
         render(root, MyComponent, props);
-        assert.equal(root.innerHTML, 'hello');
+        expect(root.innerHTML).toEqual('hello');
     });
 
     it('should mount onto an element without a key', function() {
@@ -546,10 +555,10 @@ describe('Component', function() {
         const MyComponent = createComponent(template);
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
+        expect(root.outerHTML).toEqual('<div>hello</div>');
 
         render(root, MyComponent, { text: 'test' });
-        assert.equal(root.outerHTML, '<div>test</div>');
+        expect(root.outerHTML).toEqual('<div>test</div>');
     });
 
     it('should replace components', function() {
@@ -565,10 +574,10 @@ describe('Component', function() {
         const MyOtherComponent = createComponent(template);
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
+        expect(root.outerHTML).toEqual('<div>hello</div>');
 
         render(root, MyOtherComponent, { text: 'test' });
-        assert.equal(root.outerHTML, '<div>test</div>');
+        expect(root.outerHTML).toEqual('<div>test</div>');
     });
 
     it('should unmount replaced components', function() {
@@ -589,11 +598,11 @@ describe('Component', function() {
         const MyOtherComponent = createComponent(template);
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
+        expect(root.outerHTML).toEqual('<div>hello</div>');
 
         render(root, MyOtherComponent, { text: 'test' });
-        assert.equal(root.outerHTML, '<div>test</div>');
-        assert.equal(unmounted, 1);
+        expect(root.outerHTML).toEqual('<div>test</div>');
+        expect(unmounted).toEqual(1);
     });
 
     it('should render components into an existing DOM', function() {
@@ -626,10 +635,10 @@ describe('Component', function() {
 
         const root = document.createElement('div');
         root.innerHTML = '<div>test</div>';
-        assert.equal(root.outerHTML, '<div><div>test</div></div>');
+        expect(root.outerHTML).toEqual('<div><div>test</div></div>');
         render(root, MyParentComponent, { childProps: { text: 'hello' } });
-        assert.equal(root.outerHTML, '<div><div>hello</div></div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div><div>hello</div></div>');
+        expect(mounted).toEqual(1);
     });
 
     it('should render components into an existing DOM', function() {
@@ -662,16 +671,14 @@ describe('Component', function() {
 
         const root = document.createElement('div');
         root.innerHTML = '<div key="test">test</div>';
-        assert.equal(root.outerHTML, '<div><div key="test">test</div></div>');
+        expect(root.outerHTML).toEqual('<div><div key="test">test</div></div>');
         const oldChild = root.children[0];
         render(root, MyParentComponent, { childProps: { text: 'hello' } });
-        assert.equal(root.outerHTML, '<div><div>hello</div></div>');
-        assert.equal(mounted, 1);
-        assert.notEqual(oldChild, root.children[0]);
-        assert(
-            oldChild.parentNode == null,
-            'Previous child no longer has a parent',
-        );
+        expect(root.outerHTML).toEqual('<div><div>hello</div></div>');
+        expect(mounted).toEqual(1);
+        expect(oldChild).not.toEqual(root.children[0]);
+        // 'Previous child no longer has a parent'
+        expect(oldChild.parentNode).toBeNull();
     });
 
     it('should reuse moved child components', function() {
@@ -714,23 +721,21 @@ describe('Component', function() {
         });
         const firstCompEl = root.childNodes[0];
         const secondCompEl = root.childNodes[1];
-        assert.equal(
-            root.outerHTML,
-            '<div><div>hello</div><div>world</div></div>',
+        expect(root.outerHTML).toEqual(
+            '<div><div>hello</div><div>world</div></div>'
         );
-        assert.equal(mounted, 2);
+        expect(mounted).toEqual(2);
 
         render(root, MyParentComponent, {
             flip: true,
             childProps: [{ text: 'hello' }, { text: 'world' }],
         });
-        assert.equal(
-            root.outerHTML,
-            '<div><div>world</div><div>hello</div></div>',
+        expect(root.outerHTML).toEqual(
+            '<div><div>world</div><div>hello</div></div>'
         );
-        assert.equal(firstCompEl, root.childNodes[1]);
-        assert.equal(secondCompEl, root.childNodes[0]);
-        assert.equal(mounted, 2);
+        expect(firstCompEl).toEqual(root.childNodes[1]);
+        expect(secondCompEl).toEqual(root.childNodes[0]);
+        expect(mounted).toEqual(2);
     });
 
     it('should render existing components into an existing DOM', function() {
@@ -760,16 +765,14 @@ describe('Component', function() {
 
         const root = document.createElement('div');
         root.innerHTML = '<div key="test">test</div>';
-        assert.equal(root.outerHTML, '<div><div key="test">test</div></div>');
+        expect(root.outerHTML).toEqual('<div><div key="test">test</div></div>');
         const oldChild = root.children[0];
         render(root, MyParentComponent, { childProps: { text: 'hello' } });
-        assert.equal(root.outerHTML, '<div><div>hello</div></div>');
-        assert.equal(mounted, 1);
-        assert.notEqual(oldChild, root.children[0]);
-        assert(
-            oldChild.parentNode == null,
-            'Previous child no longer has a parent',
-        );
+        expect(root.outerHTML).toEqual('<div><div>hello</div></div>');
+        expect(mounted).toEqual(1);
+        expect(oldChild).not.toEqual(root.children[0]);
+        // 'Previous child no longer has a parent'
+        expect(oldChild.parentNode).toBeNull();
     });
 
     it('should update itself when its state changes', function(done) {
@@ -792,11 +795,11 @@ describe('Component', function() {
                     return { ...state, ...action.payload };
                 }
                 return state;
-            },
+            }
         );
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
+        expect(root.outerHTML).toEqual('<div>hello</div>');
         comp.dispatch({ type: 'setText', payload: 'world' });
         flush({
             didTimeout: false,
@@ -804,7 +807,7 @@ describe('Component', function() {
                 return 10;
             },
         });
-        assert.equal(root.outerHTML, '<div>world</div>');
+        expect(root.outerHTML).toEqual('<div>world</div>');
         done();
     });
 });

--- a/packages/melody-component/__tests__/MarkDirtySpec.js
+++ b/packages/melody-component/__tests__/MarkDirtySpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { createComponent, render, RECEIVE_PROPS } from '../src';
 import { elementOpen, elementClose, component, text } from 'melody-idom';
 
@@ -41,7 +39,7 @@ it('should not try to render an already unmounted child', done => {
     const ChildComponent = createComponent(
         childTemplate,
         state => ({}),
-        instanceAccessor(i => (childInstance = i)),
+        instanceAccessor(i => (childInstance = i))
     );
 
     const parentReducer = (state = { show: true }, action) => {
@@ -74,7 +72,7 @@ it('should not try to render an already unmounted child', done => {
     const ParentComponent = createComponent(
         parentTemplate,
         parentReducer,
-        instanceAccessor(i => (parentInstance = i)),
+        instanceAccessor(i => (parentInstance = i))
     );
 
     const root = document.createElement('div');

--- a/packages/melody-component/__tests__/UnmountSpec.js
+++ b/packages/melody-component/__tests__/UnmountSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
 import { createComponent, render, unmountComponentAtNode } from '../src';
 import { component, elementOpen, elementClose, text } from 'melody-idom';
 
@@ -49,12 +48,12 @@ describe('Unmount', function() {
 
             const root = document.createElement('div');
             render(root, MyComponent);
-            assert.equal(unmounted, 0);
-            assert.equal(innerUnmounted, 0);
+            expect(unmounted).toEqual(0);
+            expect(innerUnmounted).toEqual(0);
 
             unmountComponentAtNode(root);
-            assert.equal(unmounted, 1);
-            assert.equal(innerUnmounted, 1);
+            expect(unmounted).toEqual(1);
+            expect(innerUnmounted).toEqual(1);
         });
 
         it('should remove node data', function() {
@@ -69,10 +68,10 @@ describe('Unmount', function() {
 
             const root = document.createElement('div');
             render(root, MyComponent);
-            assert(!!root['__incrementalDOMData']);
+            expect(!!root['__incrementalDOMData']).toBeTruthy();
 
             unmountComponentAtNode(root);
-            assert(!root['__incrementalDOMData']);
+            expect(!root['__incrementalDOMData']).toBeTruthy();
         });
     });
 });

--- a/packages/melody-hoc/__tests__/BindEventsSpec.js
+++ b/packages/melody-hoc/__tests__/BindEventsSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 
 import { createComponent, render } from 'melody-component';
 import {
@@ -21,10 +20,9 @@ import {
     elementOpen,
     elementClose,
     component,
-    ref,
     flush,
 } from 'melody-idom';
-import { bindEvents, lifecycle, compose } from '../src';
+import { bindEvents, compose } from '../src';
 
 const template = {
     render(_context) {
@@ -58,9 +56,9 @@ describe('BindEvents', function() {
 
         render(root, EnhancedComponent, {});
         dispatchClick(root);
-        expect(clicked).to.equal(true);
-        expect(context).to.be.a('object');
-        expect(context.props).to.be.a('object');
+        expect(clicked).toBeTruthy();
+        expect(context).toBeInstanceOf(Object);
+        expect(context.props).toBeInstanceOf(Object);
     });
     it('should unbind event handlers when unmounted', function() {
         const root = document.createElement('div');
@@ -73,7 +71,7 @@ describe('BindEvents', function() {
                         clickedCount++;
                     },
                 },
-            }),
+            })
         );
 
         const MyComponent = createComponent(template);
@@ -98,6 +96,6 @@ describe('BindEvents', function() {
         dispatchClick(croot);
         patchOuter(root, renderTemplate, { comp: false });
         dispatchClick(croot);
-        expect(clickedCount).to.equal(1);
+        expect(clickedCount).toEqual(1);
     });
 });

--- a/packages/melody-hoc/__tests__/DefaultPropsSpec.js
+++ b/packages/melody-hoc/__tests__/DefaultPropsSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 
 import { createComponent, render } from 'melody-component';
 import { elementOpen, elementClose } from 'melody-idom';
@@ -40,7 +39,7 @@ describe('DefaultProps', function() {
         const EnhancedComponent = enhance(MyComponent);
 
         render(root, EnhancedComponent, { foo: 'baz' });
-        expect(loggedProps).to.deep.equal({ qux: 'qax', foo: 'baz' });
+        expect(loggedProps).toEqual({ qux: 'qax', foo: 'baz' });
     });
     it('should fill undefined properties', function() {
         const root = document.createElement('div');
@@ -55,7 +54,7 @@ describe('DefaultProps', function() {
         const EnhancedComponent = enhance(MyComponent);
 
         render(root, EnhancedComponent, { foo: 'baz', qux: undefined });
-        expect(loggedProps).to.deep.equal({ qux: 'qax', foo: 'baz' });
+        expect(loggedProps).toEqual({ qux: 'qax', foo: 'baz' });
     });
     it('should not fill null properties', function() {
         const root = document.createElement('div');
@@ -70,7 +69,7 @@ describe('DefaultProps', function() {
         const EnhancedComponent = enhance(MyComponent);
 
         render(root, EnhancedComponent, { foo: 'baz', qux: null });
-        expect(loggedProps).to.deep.equal({ qux: null, foo: 'baz' });
+        expect(loggedProps).toEqual({ qux: null, foo: 'baz' });
     });
     it('should fill missing properties on update', function() {
         const root = document.createElement('div');
@@ -86,6 +85,6 @@ describe('DefaultProps', function() {
 
         render(root, EnhancedComponent, { foo: 'baz' });
         render(root, EnhancedComponent, {});
-        expect(loggedProps).to.deep.equal({ foo: 'bar', qux: 'qax' });
+        expect(loggedProps).toEqual({ foo: 'bar', qux: 'qax' });
     });
 });

--- a/packages/melody-hoc/__tests__/MapPropsSpec.js
+++ b/packages/melody-hoc/__tests__/MapPropsSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 
 import { createComponent, render } from 'melody-component';
 import { elementOpen, elementClose } from 'melody-idom';
@@ -40,7 +39,7 @@ describe('MapProps', function() {
         const EnhancedComponent = enhance(MyComponent);
 
         render(root, EnhancedComponent, { foo: 'bar' });
-        expect(loggedProps).to.deep.equal({ qux: 'qax', foo: 'bar' });
+        expect(loggedProps).toEqual({ qux: 'qax', foo: 'bar' });
     });
     it('should map properties on update', function() {
         const root = document.createElement('div');
@@ -56,7 +55,7 @@ describe('MapProps', function() {
 
         render(root, EnhancedComponent, { foo: 'bar' });
         render(root, EnhancedComponent, { fux: 'bax' });
-        expect(loggedProps).to.deep.equal({ qux: 'qax', fux: 'bax' });
+        expect(loggedProps).toEqual({ qux: 'qax', fux: 'bax' });
     });
     it('should be possible to use multiple mapProps hoc', () => {
         const root = document.createElement('div');
@@ -73,7 +72,7 @@ describe('MapProps', function() {
 
         render(root, EnhancedComponent, { foo: 'bar' });
         render(root, EnhancedComponent, { fux: 'bax' });
-        expect(loggedProps).to.deep.equal({
+        expect(loggedProps).toEqual({
             qux: 'qax',
             fux: 'bax',
             bux: 'bax',

--- a/packages/melody-hoc/__tests__/WithPropsSpec.js
+++ b/packages/melody-hoc/__tests__/WithPropsSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 
 import { createComponent, render } from 'melody-component';
 import { elementOpen, elementClose } from 'melody-idom';
@@ -40,7 +39,7 @@ describe('DefaultProps', function() {
         const EnhancedComponent = enhance(MyComponent);
 
         render(root, EnhancedComponent, { foo: 'baz' });
-        expect(loggedProps).to.deep.equal({ foo: 'bar', qux: 'qax' });
+        expect(loggedProps).toEqual({ foo: 'bar', qux: 'qax' });
     });
     it('should add properties on update', function() {
         const root = document.createElement('div');
@@ -56,7 +55,7 @@ describe('DefaultProps', function() {
 
         render(root, EnhancedComponent, { foo: 'baz' });
         render(root, EnhancedComponent, { doo: 'woo' });
-        expect(loggedProps).to.deep.equal({
+        expect(loggedProps).toEqual({
             foo: 'bar',
             qux: 'qax',
             doo: 'woo',

--- a/packages/melody-hooks/__tests__/ComponentSpec.js
+++ b/packages/melody-hooks/__tests__/ComponentSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render, unmountComponentAtNode } from 'melody-component';
 import {
     elementOpen,
@@ -75,7 +73,7 @@ describe('component', () => {
         }, template);
         render(root, MyComponent, { value: 'foo' });
         render(root, MyComponent, { value: 'bar' });
-        assert.equal(called, 2);
+        expect(called).toEqual(2);
     });
     it("should not rerender when props haven't changed", () => {
         const root = document.createElement('div');
@@ -86,7 +84,7 @@ describe('component', () => {
         }, template);
         render(root, MyComponent, { value: 'foo' });
         render(root, MyComponent, { value: 'foo' });
-        assert.equal(called, 1);
+        expect(called).toEqual(1);
     });
     it("should not rerender children when props haven't changed", () => {
         const childTemplate = {
@@ -132,10 +130,10 @@ describe('component', () => {
         const MyOtherComponent = createComponent(props => props, template);
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
+        expect(root.outerHTML).toEqual('<div>hello</div>');
 
         render(root, MyOtherComponent, { text: 'test' });
-        assert.equal(root.outerHTML, '<div>test</div>');
+        expect(root.outerHTML).toEqual('<div>test</div>');
     });
     it('should unmount replaced components', () => {
         const template = {
@@ -156,11 +154,11 @@ describe('component', () => {
         const MyOtherComponent = createComponent(props => props, template);
 
         render(root, MyComponent, { text: 'hello' });
-        assert.equal(root.outerHTML, '<div>hello</div>');
+        expect(root.outerHTML).toEqual('<div>hello</div>');
 
         render(root, MyOtherComponent, { text: 'test' });
-        assert.equal(root.outerHTML, '<div>test</div>');
-        assert.equal(unmounted, 1);
+        expect(root.outerHTML).toEqual('<div>test</div>');
+        expect(unmounted).toEqual(1);
     });
     it('should render components into an existing DOM', () => {
         const childTemplate = {
@@ -196,10 +194,10 @@ describe('component', () => {
 
         const root = document.createElement('div');
         root.innerHTML = '<div>test</div>';
-        assert.equal(root.outerHTML, '<div><div>test</div></div>');
+        expect(root.outerHTML).toEqual('<div><div>test</div></div>');
         render(root, MyParentComponent, { childProps: { text: 'hello' } });
-        assert.equal(root.outerHTML, '<div><div>hello</div></div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div><div>hello</div></div>');
+        expect(mounted).toEqual(1);
     });
     it('should render components into an existing DOM', () => {
         const childTemplate = {
@@ -235,16 +233,14 @@ describe('component', () => {
 
         const root = document.createElement('div');
         root.innerHTML = '<div key="test">test</div>';
-        assert.equal(root.outerHTML, '<div><div key="test">test</div></div>');
+        expect(root.outerHTML).toEqual('<div><div key="test">test</div></div>');
         const oldChild = root.children[0];
         render(root, MyParentComponent, { childProps: { text: 'hello' } });
-        assert.equal(root.outerHTML, '<div><div>hello</div></div>');
-        assert.equal(mounted, 1);
-        assert.notEqual(oldChild, root.children[0]);
-        assert(
-            oldChild.parentNode == null,
-            'Previous child no longer has a parent'
-        );
+        expect(root.outerHTML).toEqual('<div><div>hello</div></div>');
+        expect(mounted).toEqual(1);
+        expect(oldChild).not.toEqual(root.children[0]);
+        // 'Previous child no longer has a parent'
+        expect(oldChild.parentNode).toBeNull();
     });
     it('should reuse moved child components', () => {
         const childTemplate = {
@@ -290,23 +286,21 @@ describe('component', () => {
         });
         const firstCompEl = root.childNodes[0];
         const secondCompEl = root.childNodes[1];
-        assert.equal(
-            root.outerHTML,
+        expect(root.outerHTML).toEqual(
             '<div><div>hello</div><div>world</div></div>'
         );
-        assert.equal(mounted, 2);
+        expect(mounted).toEqual(2);
 
         render(root, MyParentComponent, {
             flip: true,
             childProps: [{ text: 'hello' }, { text: 'world' }],
         });
-        assert.equal(
-            root.outerHTML,
+        expect(root.outerHTML).toEqual(
             '<div><div>world</div><div>hello</div></div>'
         );
-        assert.equal(firstCompEl, root.childNodes[1]);
-        assert.equal(secondCompEl, root.childNodes[0]);
-        assert.equal(mounted, 2);
+        expect(firstCompEl).toEqual(root.childNodes[1]);
+        expect(secondCompEl).toEqual(root.childNodes[0]);
+        expect(mounted).toEqual(2);
     });
     it('should render existing components into an existing DOM', () => {
         const childTemplate = {
@@ -339,16 +333,14 @@ describe('component', () => {
 
         const root = document.createElement('div');
         root.innerHTML = '<div key="test">test</div>';
-        assert.equal(root.outerHTML, '<div><div key="test">test</div></div>');
+        expect(root.outerHTML).toEqual('<div><div key="test">test</div></div>');
         const oldChild = root.children[0];
         render(root, MyParentComponent, { childProps: { text: 'hello' } });
-        assert.equal(root.outerHTML, '<div><div>hello</div></div>');
-        assert.equal(mounted, 1);
-        assert.notEqual(oldChild, root.children[0]);
-        assert(
-            oldChild.parentNode == null,
-            'Previous child no longer has a parent'
-        );
+        expect(root.outerHTML).toEqual('<div><div>hello</div></div>');
+        expect(mounted).toEqual(1);
+        expect(oldChild).not.toEqual(root.children[0]);
+        // 'Previous child no longer has a parent'
+        expect(oldChild.parentNode).toBeNull();
     });
     it('should trigger unmount callback when a Component is removed', () => {
         const template = {
@@ -382,13 +374,15 @@ describe('component', () => {
 
         patchOuter(root, renderTemplate, { comp: true });
         flush();
-        assert.equal(root.innerHTML, '<div><p>hello</p><span>foo</span></div>');
-        assert.equal(unmounted, 0);
+        expect(root.innerHTML).toEqual(
+            '<div><p>hello</p><span>foo</span></div>'
+        );
+        expect(unmounted).toEqual(0);
 
         patchOuter(root, renderTemplate, { comp: false });
         flush();
-        assert.equal(root.innerHTML, '');
-        assert.equal(unmounted, 1);
+        expect(root.innerHTML).toEqual('');
+        expect(unmounted).toEqual(1);
     });
 
     it('should trigger unmount callback when a Component is removed within an element', () => {
@@ -420,13 +414,13 @@ describe('component', () => {
 
         patchOuter(root, renderTemplate, { comp: true });
         flush();
-        assert.equal(root.innerHTML, '<div><div>hello</div></div>');
-        assert.equal(unmounted, 0);
+        expect(root.innerHTML).toEqual('<div><div>hello</div></div>');
+        expect(unmounted).toEqual(0);
 
         patchOuter(root, renderTemplate, { comp: false });
         flush();
-        assert.equal(root.innerHTML, '');
-        assert.equal(unmounted, 1);
+        expect(root.innerHTML).toEqual('');
+        expect(unmounted).toEqual(1);
     });
     it('should trigger unmount callback for child components when a Component is removed', () => {
         let MyComponent;
@@ -465,13 +459,13 @@ describe('component', () => {
 
         patchOuter(root, renderTemplate, { comp: true });
         flush();
-        assert.equal(root.innerHTML, '<div>hello<div>world</div></div>');
-        assert.equal(mounted, 2);
+        expect(root.innerHTML).toEqual('<div>hello<div>world</div></div>');
+        expect(mounted).toEqual(2);
 
         patchOuter(root, renderTemplate, { comp: false });
         flush();
-        assert.equal(root.innerHTML, '');
-        assert.equal(mounted, 0);
+        expect(root.innerHTML).toEqual('');
+        expect(mounted).toEqual(0);
     });
     it('should trigger unmount callback for deep nested child components when a Component is removed', () => {
         const mounted = { inner: 0, middle: 0, outer: 0 };
@@ -519,17 +513,17 @@ describe('component', () => {
 
         patchOuter(root, renderTemplate, { comp: true });
         flush();
-        assert.equal(root.innerHTML, '<div><div><div></div></div></div>');
-        assert.equal(mounted.inner, 1);
-        assert.equal(mounted.middle, 1);
-        assert.equal(mounted.outer, 1);
+        expect(root.innerHTML).toEqual('<div><div><div></div></div></div>');
+        expect(mounted.inner).toEqual(1);
+        expect(mounted.middle).toEqual(1);
+        expect(mounted.outer).toEqual(1);
 
         patchOuter(root, renderTemplate, { comp: false });
         flush();
-        assert.equal(root.innerHTML, '');
-        assert.equal(mounted.inner, 0);
-        assert.equal(mounted.middle, 0);
-        assert.equal(mounted.outer, 0);
+        expect(root.innerHTML).toEqual('');
+        expect(mounted.inner).toEqual(0);
+        expect(mounted.middle).toEqual(0);
+        expect(mounted.outer).toEqual(0);
     });
     it('should trigger unmount callback for deep nested child components when a Component is removed', () => {
         const mounted = { innermost: 0, inner: 0, middle: 0, outer: 0 };
@@ -581,16 +575,16 @@ describe('component', () => {
         });
 
         render(root, OuterComponent, { comp: true });
-        assert.equal(root.innerHTML, '<div><div><div></div></div></div>');
-        assert.equal(mounted.inner, 1);
-        assert.equal(mounted.middle, 1);
-        assert.equal(mounted.outer, 1);
+        expect(root.innerHTML).toEqual('<div><div><div></div></div></div>');
+        expect(mounted.inner).toEqual(1);
+        expect(mounted.middle).toEqual(1);
+        expect(mounted.outer).toEqual(1);
 
         render(root, OuterComponent, { comp: false });
-        assert.equal(root.innerHTML, '');
-        assert.equal(mounted.inner, 0);
-        assert.equal(mounted.middle, 0);
-        assert.equal(mounted.outer, 1);
+        expect(root.innerHTML).toEqual('');
+        expect(mounted.inner).toEqual(0);
+        expect(mounted.middle).toEqual(0);
+        expect(mounted.outer).toEqual(1);
     });
 
     it('should trigger mount callback once even for nested components', () => {
@@ -624,12 +618,12 @@ describe('component', () => {
 
         const root = document.createElement('div');
         render(root, MyParentComponent, { childProps: { text: 'hello' } });
-        assert.equal(root.outerHTML, '<div><div>hello</div></div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div><div>hello</div></div>');
+        expect(mounted).toEqual(1);
 
         render(root, MyParentComponent, { childProps: { text: 'test' } });
-        assert.equal(root.outerHTML, '<div><div>test</div></div>');
-        assert.equal(mounted, 1);
+        expect(root.outerHTML).toEqual('<div><div>test</div></div>');
+        expect(mounted).toEqual(1);
     });
     it('should not throw when calling setState after the component has been unmounted', () => {
         const root = document.createElement('div');
@@ -671,12 +665,12 @@ describe('component', () => {
         }, template);
 
         render(root, MyComponent, { value: 'foo' });
-        assert.equal(root.outerHTML, '<div>foo</div>');
-        assert.throws(() => {
+        expect(root.outerHTML).toEqual('<div>foo</div>');
+        expect(() => {
             render(root, MyComponent);
-        });
-        assert.equal(root.outerHTML, '<div>foo</div>');
+        }).toThrow();
+        expect(root.outerHTML).toEqual('<div>foo</div>');
         render(root, MyComponent, { value: 'foo' });
-        assert.equal(root.outerHTML, '<div>foo</div>');
+        expect(root.outerHTML).toEqual('<div>foo</div>');
     });
 });

--- a/packages/melody-hooks/__tests__/HooksSpec.js
+++ b/packages/melody-hooks/__tests__/HooksSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render } from 'melody-component';
 import { elementOpen, elementClose, text } from 'melody-idom';
 import { createComponent, useState, useEffect } from '../src';
@@ -29,9 +27,12 @@ const template = {
 
 describe('hooks', () => {
     it('should throw when calling hooks outside of a component functions', () => {
-        assert.throws(() => {
+        const error = new Error(
+            'Cannot use hooks outside of component functions'
+        );
+        expect(() => {
             useState(0);
-        }, 'Cannot use hooks outside of component functions');
+        }).toThrow(error);
     });
     it('should throw when hook slots differ', () => {
         const root = document.createElement('div');
@@ -46,9 +47,11 @@ describe('hooks', () => {
             }
         }, template);
         render(root, MyComponent);
-
-        assert.throws(() => {
+        const error = new Error(
+            'The order of hooks changed. This breaks the internals of the component. It is not allowed to call hooks inside loops, conditions, or nested functions'
+        );
+        expect(() => {
             setter(1);
-        }, 'The order of hooks changed. This breaks the internals of the component. It is not allowed to call hooks inside loops, conditions, or nested functions');
+        }).toThrow(error);
     });
 });

--- a/packages/melody-hooks/__tests__/UseCallbackSpec.js
+++ b/packages/melody-hooks/__tests__/UseCallbackSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render } from 'melody-component';
 import { elementOpen, elementClose, text } from 'melody-idom';
 import { createComponent, useState, useCallback } from '../src';
@@ -46,8 +44,8 @@ describe('useCallback', () => {
             flush();
             setter(false);
             flush();
-            assert.equal(callbacks[0] !== callbacks[1], true);
-            assert.equal(callbacks[1] !== callbacks[2], true);
+            expect(callbacks[0] !== callbacks[1]).toBeTruthy();
+            expect(callbacks[1] !== callbacks[2]).toBeTruthy();
         });
     });
     describe('with inputs being specified', () => {
@@ -70,8 +68,8 @@ describe('useCallback', () => {
             flush();
             setter(true);
             flush();
-            assert.equal(callbacks[0] === callbacks[1], true);
-            assert.equal(callbacks[1] !== callbacks[2], true);
+            expect(callbacks[0] === callbacks[1]).toBeTruthy();
+            expect(callbacks[1] !== callbacks[2]).toBeTruthy();
         });
         it('should return the same callback when inputs are empty', () => {
             const root = document.createElement('div');
@@ -92,8 +90,8 @@ describe('useCallback', () => {
             flush();
             setter(true);
             flush();
-            assert.equal(callbacks[0] === callbacks[1], true);
-            assert.equal(callbacks[1] === callbacks[2], true);
+            expect(callbacks[0] === callbacks[1]).toBeTruthy();
+            expect(callbacks[1] === callbacks[2]).toBeTruthy();
         });
     });
 });

--- a/packages/melody-hooks/__tests__/UseEffectSpec.js
+++ b/packages/melody-hooks/__tests__/UseEffectSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render, unmountComponentAtNode } from 'melody-component';
 import { elementOpen, elementClose, text } from 'melody-idom';
 import { createComponent, useState, useEffect, useEffectOnce } from '../src';
@@ -44,13 +42,13 @@ describe('useEffect', () => {
                 });
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 2);
+            expect(called).toEqual(2);
             rerender(unique());
             flush();
-            assert.equal(called, 3);
+            expect(called).toEqual(3);
         });
         it('should call effect on mount', () => {
             const root = document.createElement('div');
@@ -63,10 +61,10 @@ describe('useEffect', () => {
                 }, []);
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
         });
         it('should call effect on mount and when a value changes', () => {
             const root = document.createElement('div');
@@ -78,30 +76,27 @@ describe('useEffect', () => {
                 const state = useState(0);
                 const value = state[0];
                 setValue = state[1];
-                useEffect(
-                    () => {
-                        called++;
-                    },
-                    [value]
-                );
+                useEffect(() => {
+                    called++;
+                }, [value]);
                 return {
                     value,
                 };
             }, template);
             render(root, MyComponent);
-            assert.equal(root.outerHTML, '<div>0</div>');
-            assert.equal(called, 1);
+            expect(root.outerHTML).toEqual('<div>0</div>');
+            expect(called).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
             setValue(1);
             flush();
-            assert.equal(root.outerHTML, '<div>1</div>');
-            assert.equal(called, 2);
+            expect(root.outerHTML).toEqual('<div>1</div>');
+            expect(called).toEqual(2);
             rerender(unique());
             flush();
-            assert.equal(root.outerHTML, '<div>1</div>');
-            assert.equal(called, 2);
+            expect(root.outerHTML).toEqual('<div>1</div>');
+            expect(called).toEqual(2);
         });
         it('should not reset `dirty` when multiple updates come in', () => {
             const root = document.createElement('div');
@@ -123,17 +118,17 @@ describe('useEffect', () => {
                 };
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
             setValue(['a']);
             flush();
-            assert.equal(called, 2);
+            expect(called).toEqual(2);
             setValue(['a', 'b']);
             // the second call to setValue should not reset the hook's internal `dirty` property,
             // value.length will be 2 for both times `setValue` is called.
             // here we test that once dirty is true, it will not be resetted
             setValue(['a', 'c']);
             flush();
-            assert.equal(called, 3);
+            expect(called).toEqual(3);
         });
         it('should ignore unsubscribe if it is not a function', () => {
             const root = document.createElement('div');
@@ -169,18 +164,18 @@ describe('useEffect', () => {
                 });
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             rerender(unique());
             flush();
-            assert.equal(called, 2);
-            assert.equal(calledUnsubscribe, 1);
+            expect(called).toEqual(2);
+            expect(calledUnsubscribe).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 3);
-            assert.equal(calledUnsubscribe, 2);
+            expect(called).toEqual(3);
+            expect(calledUnsubscribe).toEqual(2);
             unmountComponentAtNode(root);
-            assert.equal(calledUnsubscribe, 3);
+            expect(calledUnsubscribe).toEqual(3);
         });
         it('should call effect on mount and unsubscribe on unmount', () => {
             const root = document.createElement('div');
@@ -197,14 +192,14 @@ describe('useEffect', () => {
                 }, []);
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             unmountComponentAtNode(root);
-            assert.equal(calledUnsubscribe, 1);
+            expect(calledUnsubscribe).toEqual(1);
         });
         it('should call effect on mount and when a value changes', () => {
             const root = document.createElement('div');
@@ -217,38 +212,35 @@ describe('useEffect', () => {
                 const state = useState(0);
                 const value = state[0];
                 setValue = state[1];
-                useEffect(
-                    () => {
-                        called++;
-                        return () => {
-                            calledUnsubscribe++;
-                        };
-                    },
-                    [value]
-                );
+                useEffect(() => {
+                    called++;
+                    return () => {
+                        calledUnsubscribe++;
+                    };
+                }, [value]);
                 return {
                     value,
                 };
             }, template);
             render(root, MyComponent);
-            assert.equal(root.outerHTML, '<div>0</div>');
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(root.outerHTML).toEqual('<div>0</div>');
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             setValue(1);
             flush();
-            assert.equal(root.outerHTML, '<div>1</div>');
-            assert.equal(called, 2);
-            assert.equal(calledUnsubscribe, 1);
+            expect(root.outerHTML).toEqual('<div>1</div>');
+            expect(called).toEqual(2);
+            expect(calledUnsubscribe).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(root.outerHTML, '<div>1</div>');
-            assert.equal(called, 2);
+            expect(root.outerHTML).toEqual('<div>1</div>');
+            expect(called).toEqual(2);
             unmountComponentAtNode(root);
-            assert.equal(calledUnsubscribe, 2);
+            expect(calledUnsubscribe).toEqual(2);
         });
     });
 });
@@ -265,10 +257,10 @@ describe('useEffectOnce', () => {
                 });
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
         });
     });
     describe('with unsubscribe', () => {
@@ -287,14 +279,14 @@ describe('useEffectOnce', () => {
                 });
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             unmountComponentAtNode(root);
-            assert.equal(calledUnsubscribe, 1);
+            expect(calledUnsubscribe).toEqual(1);
         });
     });
 });

--- a/packages/melody-hooks/__tests__/UseMemoSpec.js
+++ b/packages/melody-hooks/__tests__/UseMemoSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render } from 'melody-component';
 import { elementOpen, elementClose, text } from 'melody-idom';
 import { createComponent, useState, useMemo } from '../src';
@@ -49,8 +47,8 @@ describe('useMemo', () => {
             flush();
             setter(false);
             flush();
-            assert.equal(values[0] !== values[1], true);
-            assert.equal(values[1] !== values[2], true);
+            expect(values[0] !== values[1]).toBeTruthy();
+            expect(values[1] !== values[2]).toBeTruthy();
         });
     });
     describe('with inputs being specified', () => {
@@ -76,8 +74,8 @@ describe('useMemo', () => {
             flush();
             setter(true);
             flush();
-            assert.equal(values[0] === values[1], true);
-            assert.equal(values[1] !== values[2], true);
+            expect(values[0] === values[1]).toBeTruthy();
+            expect(values[1] !== values[2]).toBeTruthy();
         });
         it('should not call the getter when inputs are empty', () => {
             const root = document.createElement('div');
@@ -101,8 +99,8 @@ describe('useMemo', () => {
             flush();
             setter(true);
             flush();
-            assert.equal(values[0] === values[1], true);
-            assert.equal(values[1] === values[2], true);
+            expect(values[0] === values[1]).toBeTruthy();
+            expect(values[1] === values[2]).toBeTruthy();
         });
     });
 });

--- a/packages/melody-hooks/__tests__/UseMutationEffectSpec.js
+++ b/packages/melody-hooks/__tests__/UseMutationEffectSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render, unmountComponentAtNode } from 'melody-component';
 import { elementOpen, elementClose, text } from 'melody-idom';
 import {
@@ -51,7 +49,7 @@ describe('useMutationEffect', () => {
                 });
             }, template);
             render(root, MyComponent);
-            assert.deepEqual(log, ['mutation', 'effect']);
+            expect(log).toEqual(['mutation', 'effect']);
         });
     });
     describe('setState', () => {
@@ -63,9 +61,11 @@ describe('useMutationEffect', () => {
                     setValue(1);
                 });
             }, template);
-            assert.throws(() => {
+            const error =
+                'Melody does not allow using `setState` in `useMutationEffect` since this would harm rendering performance. This hook is meant for manually mutating the DOM';
+            expect(() => {
                 render(root, MyComponent);
-            }, 'Melody does not allow using `setState` in `useMutationEffect` since this would harm rendering performance. This hook is meant for manually mutating the DOM');
+            }).toThrow(error);
         });
     });
     describe('refs', () => {
@@ -87,7 +87,7 @@ describe('useMutationEffect', () => {
                 return { myref };
             }, template);
             render(root, MyComponent);
-            assert.instanceOf(ref, HTMLDivElement);
+            expect(ref).toBeInstanceOf(HTMLDivElement);
         });
     });
     describe('without unsubscribe', () => {
@@ -102,13 +102,13 @@ describe('useMutationEffect', () => {
                 });
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 2);
+            expect(called).toEqual(2);
             rerender(unique());
             flush();
-            assert.equal(called, 3);
+            expect(called).toEqual(3);
         });
         it('should call mutation effect on mount', () => {
             const root = document.createElement('div');
@@ -121,10 +121,10 @@ describe('useMutationEffect', () => {
                 }, []);
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
         });
         it('should call mutation effect on mount and when a value changes', () => {
             const root = document.createElement('div');
@@ -136,30 +136,27 @@ describe('useMutationEffect', () => {
                 const state = useState(0);
                 const value = state[0];
                 setValue = state[1];
-                useMutationEffect(
-                    () => {
-                        called++;
-                    },
-                    [value]
-                );
+                useMutationEffect(() => {
+                    called++;
+                }, [value]);
                 return {
                     value,
                 };
             }, template);
             render(root, MyComponent);
-            assert.equal(root.outerHTML, '<div>0</div>');
-            assert.equal(called, 1);
+            expect(root.outerHTML).toEqual('<div>0</div>');
+            expect(called).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
+            expect(called).toEqual(1);
             setValue(1);
             flush();
-            assert.equal(root.outerHTML, '<div>1</div>');
-            assert.equal(called, 2);
+            expect(root.outerHTML).toEqual('<div>1</div>');
+            expect(called).toEqual(2);
             rerender(unique());
             flush();
-            assert.equal(root.outerHTML, '<div>1</div>');
-            assert.equal(called, 2);
+            expect(root.outerHTML).toEqual('<div>1</div>');
+            expect(called).toEqual(2);
         });
     });
     describe('with unsubscribe', () => {
@@ -178,18 +175,18 @@ describe('useMutationEffect', () => {
                 });
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             rerender(unique());
             flush();
-            assert.equal(called, 2);
-            assert.equal(calledUnsubscribe, 1);
+            expect(called).toEqual(2);
+            expect(calledUnsubscribe).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(called, 3);
-            assert.equal(calledUnsubscribe, 2);
+            expect(called).toEqual(3);
+            expect(calledUnsubscribe).toEqual(2);
             unmountComponentAtNode(root);
-            assert.equal(calledUnsubscribe, 3);
+            expect(calledUnsubscribe).toEqual(3);
         });
         it('should call mutation effect on mount and unsubscribe on unmount', () => {
             const root = document.createElement('div');
@@ -206,14 +203,14 @@ describe('useMutationEffect', () => {
                 }, []);
             }, template);
             render(root, MyComponent);
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             unmountComponentAtNode(root);
-            assert.equal(calledUnsubscribe, 1);
+            expect(calledUnsubscribe).toEqual(1);
         });
         it('should call mutation effect on mount and when a value changes', () => {
             const root = document.createElement('div');
@@ -226,38 +223,35 @@ describe('useMutationEffect', () => {
                 const state = useState(0);
                 const value = state[0];
                 setValue = state[1];
-                useMutationEffect(
-                    () => {
-                        called++;
-                        return () => {
-                            calledUnsubscribe++;
-                        };
-                    },
-                    [value]
-                );
+                useMutationEffect(() => {
+                    called++;
+                    return () => {
+                        calledUnsubscribe++;
+                    };
+                }, [value]);
                 return {
                     value,
                 };
             }, template);
             render(root, MyComponent);
-            assert.equal(root.outerHTML, '<div>0</div>');
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(root.outerHTML).toEqual('<div>0</div>');
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             rerender(unique());
             flush();
-            assert.equal(called, 1);
-            assert.equal(calledUnsubscribe, 0);
+            expect(called).toEqual(1);
+            expect(calledUnsubscribe).toEqual(0);
             setValue(1);
             flush();
-            assert.equal(root.outerHTML, '<div>1</div>');
-            assert.equal(called, 2);
-            assert.equal(calledUnsubscribe, 1);
+            expect(root.outerHTML).toEqual('<div>1</div>');
+            expect(called).toEqual(2);
+            expect(calledUnsubscribe).toEqual(1);
             rerender(unique());
             flush();
-            assert.equal(root.outerHTML, '<div>1</div>');
-            assert.equal(called, 2);
+            expect(root.outerHTML).toEqual('<div>1</div>');
+            expect(called).toEqual(2);
             unmountComponentAtNode(root);
-            assert.equal(calledUnsubscribe, 2);
+            expect(calledUnsubscribe).toEqual(2);
         });
     });
 });

--- a/packages/melody-hooks/__tests__/UsePreviousSpec.js
+++ b/packages/melody-hooks/__tests__/UsePreviousSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render } from 'melody-component';
 import { elementOpen, elementClose, text } from 'melody-idom';
 import { createComponent, useState, usePrevious } from '../src';
@@ -39,12 +37,12 @@ describe('usePrevious', () => {
             return { value: JSON.stringify({ value, prev }) };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>{"value":0}</div>');
+        expect(root.outerHTML).toEqual('<div>{"value":0}</div>');
         setter(2);
         flush();
-        assert.equal(root.outerHTML, '<div>{"value":2,"prev":0}</div>');
+        expect(root.outerHTML).toEqual('<div>{"value":2,"prev":0}</div>');
         setter(1337);
         flush();
-        assert.equal(root.outerHTML, '<div>{"value":1337,"prev":2}</div>');
+        expect(root.outerHTML).toEqual('<div>{"value":1337,"prev":2}</div>');
     });
 });

--- a/packages/melody-hooks/__tests__/UseReducerSpec.js
+++ b/packages/melody-hooks/__tests__/UseReducerSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render } from 'melody-component';
 import { elementOpen, elementClose, text } from 'melody-idom';
 import { createComponent, useReducer } from '../src';
@@ -53,7 +51,7 @@ describe('useReducer', () => {
             return { value: JSON.stringify(value) };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>{"foo":"bar","bar":"foo"}</div>');
+        expect(root.outerHTML).toEqual('<div>{"foo":"bar","bar":"foo"}</div>');
     });
     it('should update when an action is dispatched', () => {
         const root = document.createElement('div');
@@ -64,10 +62,10 @@ describe('useReducer', () => {
             return { value: JSON.stringify(state) };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>{"foo":"bar","bar":"foo"}</div>');
+        expect(root.outerHTML).toEqual('<div>{"foo":"bar","bar":"foo"}</div>');
         setter({ type: 'FOO_CHANGED', payload: 'qux' });
         flush();
-        assert.equal(root.outerHTML, '<div>{"foo":"qux","bar":"foo"}</div>');
+        expect(root.outerHTML).toEqual('<div>{"foo":"qux","bar":"foo"}</div>');
     });
     it('should not update when an unhandled action is dispatched', () => {
         const root = document.createElement('div');
@@ -80,11 +78,11 @@ describe('useReducer', () => {
             return { value: JSON.stringify(state) };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>{"foo":"bar","bar":"foo"}</div>');
+        expect(root.outerHTML).toEqual('<div>{"foo":"bar","bar":"foo"}</div>');
         setter({ type: 'UNHANDLED', payload: 42 });
         flush();
-        assert.equal(root.outerHTML, '<div>{"foo":"bar","bar":"foo"}</div>');
-        assert.equal(called, 1);
+        expect(root.outerHTML).toEqual('<div>{"foo":"bar","bar":"foo"}</div>');
+        expect(called).toEqual(1);
     });
     it('should throw when no reducer function was passed', () => {
         const root = document.createElement('div');
@@ -92,8 +90,11 @@ describe('useReducer', () => {
             const [value] = useReducer();
             return { value: JSON.stringify(value) };
         }, template);
-        assert.throws(() => {
+        const error = new Error(
+            '`useReducer` expects a reducer function as first argument'
+        );
+        expect(() => {
             render(root, MyComponent);
-        }, '`useReducer` expects a reducer function as first argument');
+        }).toThrow(error);
     });
 });

--- a/packages/melody-hooks/__tests__/UseRefSpec.js
+++ b/packages/melody-hooks/__tests__/UseRefSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render } from 'melody-component';
 import { component, elementOpen, elementClose, elementVoid } from 'melody-idom';
 import { createComponent, useState, useEffect, useRef } from '../src';
@@ -52,8 +50,8 @@ describe('useRef', () => {
             return { myref };
         }, template);
         render(root, MyComponent);
-        assert.equal(current, null);
-        assert.instanceOf(currentInEffect, HTMLDivElement);
+        expect(current).toBeNull();
+        expect(currentInEffect).toBeInstanceOf(HTMLDivElement);
     });
     it('should remove the reference when a component is unmounted', () => {
         const root = document.createElement('div');
@@ -74,10 +72,10 @@ describe('useRef', () => {
         );
         const Parent = createParentComponent(Child);
         render(root, Parent, { show: true });
-        assert.equal(getRefCounter(ref), 0);
+        expect(getRefCounter(ref)).toEqual(0);
         render(root, Parent, { show: false });
-        assert.equal(getRefCounter(ref), -1);
-        assert.equal(ref.current, undefined);
+        expect(getRefCounter(ref)).toEqual(-1);
+        expect(ref.current).toBeUndefined();
     });
     it('should move the reference to another element', () => {
         const template = {
@@ -120,18 +118,18 @@ describe('useRef', () => {
             return { myref, foo };
         }, template);
         render(root, MyComponent);
-        assert.equal(current, null);
-        assert.equal(currentInEffect.className, 'bar');
-        assert.equal(getRefCounter(ref), 0);
+        expect(current).toBeNull();
+        expect(currentInEffect.className).toEqual('bar');
+        expect(getRefCounter(ref)).toEqual(0);
         setter(true);
         flush();
-        assert.equal(current.className, 'bar');
-        assert.equal(currentInEffect.className, 'foo');
-        assert.equal(getRefCounter(ref), 0);
+        expect(current.className).toEqual('bar');
+        expect(currentInEffect.className).toEqual('foo');
+        expect(getRefCounter(ref)).toEqual(0);
         setter(false);
         flush();
-        assert.equal(current.className, 'foo');
-        assert.equal(getRefCounter(ref), 0);
+        expect(current.className).toEqual('foo');
+        expect(getRefCounter(ref)).toEqual(0);
     });
     it('should move the reference to another element 2', () => {
         const template = {
@@ -174,17 +172,17 @@ describe('useRef', () => {
             return { myref, foo };
         }, template);
         render(root, MyComponent);
-        assert.equal(current, null);
-        assert.equal(currentInEffect.className, 'foo');
-        assert.equal(getRefCounter(ref), 0);
+        expect(current).toBeNull();
+        expect(currentInEffect.className).toEqual('foo');
+        expect(getRefCounter(ref)).toEqual(0);
         setter(true);
         flush();
-        assert.equal(current.className, 'foo');
-        assert.equal(currentInEffect.className, 'bar');
-        assert.equal(getRefCounter(ref), 0);
+        expect(current.className).toEqual('foo');
+        expect(currentInEffect.className).toEqual('bar');
+        expect(getRefCounter(ref)).toEqual(0);
         setter(false);
         flush();
-        assert.equal(current.className, 'bar');
-        assert.equal(getRefCounter(ref), 0);
+        expect(current.className).toEqual('bar');
+        expect(getRefCounter(ref)).toEqual(0);
     });
 });

--- a/packages/melody-hooks/__tests__/UseStateSpec.js
+++ b/packages/melody-hooks/__tests__/UseStateSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { render } from 'melody-component';
 import { elementOpen, elementClose, text } from 'melody-idom';
 import { createComponent, useState, useEffect } from '../src';
@@ -36,7 +34,7 @@ describe('useState', () => {
             return { value };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>foo</div>');
+        expect(root.outerHTML).toEqual('<div>foo</div>');
     });
     it('should read multiple initial values from useState hooks', () => {
         const root = document.createElement('div');
@@ -46,7 +44,7 @@ describe('useState', () => {
             return { value: foo + bar };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>foobar</div>');
+        expect(root.outerHTML).toEqual('<div>foobar</div>');
     });
     it('should update when state is changed', () => {
         const root = document.createElement('div');
@@ -58,10 +56,10 @@ describe('useState', () => {
             return { value: foo + bar };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>foobar</div>');
+        expect(root.outerHTML).toEqual('<div>foobar</div>');
         setter('bar');
         flush();
-        assert.equal(root.outerHTML, '<div>barbar</div>');
+        expect(root.outerHTML).toEqual('<div>barbar</div>');
     });
     it('should update when state is changed 2', () => {
         const root = document.createElement('div');
@@ -73,10 +71,10 @@ describe('useState', () => {
             return { value: foo + bar };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>foobar</div>');
+        expect(root.outerHTML).toEqual('<div>foobar</div>');
         setter('foo');
         flush();
-        assert.equal(root.outerHTML, '<div>foofoo</div>');
+        expect(root.outerHTML).toEqual('<div>foofoo</div>');
     });
     it("should not update when state hasn't changed", () => {
         const root = document.createElement('div');
@@ -91,7 +89,7 @@ describe('useState', () => {
         render(root, MyComponent);
         setter({ bar: 'foo', foo: 'bar' });
         flush();
-        assert.equal(called, 1);
+        expect(called).toEqual(1);
     });
     it('should be possible to pass a function to set the state', () => {
         const root = document.createElement('div');
@@ -108,10 +106,10 @@ describe('useState', () => {
             return { value: JSON.stringify(state) };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>{"counter":1,"foo":"bar"}</div>');
+        expect(root.outerHTML).toEqual('<div>{"counter":1,"foo":"bar"}</div>');
         flush();
-        assert.equal(root.outerHTML, '<div>{"counter":2,"foo":"bar"}</div>');
-        assert.equal(called, 2);
+        expect(root.outerHTML).toEqual('<div>{"counter":2,"foo":"bar"}</div>');
+        expect(called).toEqual(2);
     });
     it('should have the correct value when called subsequently', () => {
         const root = document.createElement('div');
@@ -126,10 +124,10 @@ describe('useState', () => {
             return { value };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>0</div>');
+        expect(root.outerHTML).toEqual('<div>0</div>');
         flush();
-        assert.equal(root.outerHTML, '<div>2</div>');
-        assert.equal(called, 2);
+        expect(root.outerHTML).toEqual('<div>2</div>');
+        expect(called).toEqual(2);
     });
     it('should have the correct value when called subsequently 2', () => {
         const root = document.createElement('div');
@@ -144,10 +142,10 @@ describe('useState', () => {
             return { value };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>0</div>');
+        expect(root.outerHTML).toEqual('<div>0</div>');
         flush();
-        assert.equal(root.outerHTML, '<div>NaN</div>');
-        assert.equal(called, 2);
+        expect(root.outerHTML).toEqual('<div>NaN</div>');
+        expect(called).toEqual(2);
     });
     it('should be possible to pass a function as initialState', () => {
         const root = document.createElement('div');
@@ -156,7 +154,7 @@ describe('useState', () => {
             return { value };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>foo</div>');
+        expect(root.outerHTML).toEqual('<div>foo</div>');
     });
     it('should update from an effect', () => {
         const root = document.createElement('div');
@@ -170,10 +168,10 @@ describe('useState', () => {
             return { value: foo };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>foo</div>');
+        expect(root.outerHTML).toEqual('<div>foo</div>');
         flush();
-        assert.equal(root.outerHTML, '<div>bar</div>');
-        assert.equal(called, 2);
+        expect(root.outerHTML).toEqual('<div>bar</div>');
+        expect(called).toEqual(2);
     });
     it('should only update once from an effect', () => {
         const root = document.createElement('div');
@@ -189,10 +187,10 @@ describe('useState', () => {
             return { value: foo + bar };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>foobar</div>');
+        expect(root.outerHTML).toEqual('<div>foobar</div>');
         flush();
-        assert.equal(root.outerHTML, '<div>barfoo</div>');
-        assert.equal(called, 2);
+        expect(root.outerHTML).toEqual('<div>barfoo</div>');
+        expect(called).toEqual(2);
     });
     it('should apply setState calls from the component function without rerendering', () => {
         const root = document.createElement('div');
@@ -210,9 +208,9 @@ describe('useState', () => {
             return { value: foo + bar };
         }, template);
         render(root, MyComponent);
-        assert.equal(root.outerHTML, '<div>foo2bar2</div>');
-        assert.equal(called, 2);
-        assert.deepEqual(values, ['foo', 'bar', 'foo2', 'bar2']);
+        expect(root.outerHTML).toEqual('<div>foo2bar2</div>');
+        expect(called).toEqual(2);
+        expect(values).toEqual(['foo', 'bar', 'foo2', 'bar2']);
     });
     it('should throw when component function leads to an infinite loop', () => {
         const root = document.createElement('div');
@@ -222,8 +220,8 @@ describe('useState', () => {
             return { value };
         }, template);
 
-        assert.throws(() => {
+        expect(() => {
             render(root, MyComponent);
-        }, 'Too many re-renders. Melody limits the number of renders to prevent an infinite loop.');
+        }).toThrow();
     });
 });

--- a/packages/melody-idom/__tests__/AttributesSpec.ts
+++ b/packages/melody-idom/__tests__/AttributesSpec.ts
@@ -25,7 +25,6 @@ import {
     elementVoid,
 } from '../src';
 import { importNode } from '../src/node_data';
-import { expect } from 'chai';
 
 describe('attribute updates', () => {
     let container;
@@ -57,7 +56,7 @@ describe('attribute updates', () => {
             );
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-expanded')).to.equal('hello');
+            expect(el.getAttribute('data-expanded')).toEqual('hello');
         });
 
         it('should be present when falsy', () => {
@@ -68,7 +67,7 @@ describe('attribute updates', () => {
             );
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-expanded')).to.equal('false');
+            expect(el.getAttribute('data-expanded')).toEqual('false');
         });
 
         it('should be not present when undefined', () => {
@@ -81,9 +80,9 @@ describe('attribute updates', () => {
             );
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-expanded')).to.equal(null);
-            expect(el.getAttribute('id')).to.equal(null);
-            expect(el.getAttribute('tabindex')).to.equal(null);
+            expect(el.getAttribute('data-expanded')).toBeNull();
+            expect(el.getAttribute('id')).toBeNull();
+            expect(el.getAttribute('tabindex')).toBeNull();
         });
 
         it('should update the DOM when they change', () => {
@@ -99,7 +98,7 @@ describe('attribute updates', () => {
             );
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-expanded')).to.equal('bar');
+            expect(el.getAttribute('data-expanded')).toEqual('bar');
         });
 
         it('should update different attribute in same position', () => {
@@ -115,8 +114,8 @@ describe('attribute updates', () => {
             );
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-bar')).to.equal('foo');
-            expect(el.getAttribute('data-foo')).to.equal(null);
+            expect(el.getAttribute('data-bar')).toEqual('foo');
+            expect(el.getAttribute('data-foo')).toBeNull();
         });
 
         describe('for attributes in different position', () => {
@@ -134,8 +133,8 @@ describe('attribute updates', () => {
                 );
                 const el = container.childNodes[0];
 
-                expect(el.getAttribute('data-foo')).to.equal(null);
-                expect(el.getAttribute('data-bar')).to.equal('bar');
+                expect(el.getAttribute('data-foo')).toBeNull();
+                expect(el.getAttribute('data-bar')).toEqual('bar');
             });
 
             it('should keep attribute that is moved back', () => {
@@ -152,8 +151,8 @@ describe('attribute updates', () => {
                 );
                 const el = container.childNodes[0];
 
-                expect(el.getAttribute('data-foo')).to.equal('foo');
-                expect(el.getAttribute('data-bar')).to.equal('bar');
+                expect(el.getAttribute('data-foo')).toEqual('foo');
+                expect(el.getAttribute('data-bar')).toEqual('bar');
             });
 
             it('should keep attribute that is moved up then kept', () => {
@@ -172,18 +171,18 @@ describe('attribute updates', () => {
                 );
                 const el = container.childNodes[0];
 
-                expect(el.getAttribute('data-foo')).to.equal(null);
-                expect(el.getAttribute('data-bar')).to.equal('bar');
-                expect(el.getAttribute('data-baz')).to.equal('baz');
+                expect(el.getAttribute('data-foo')).toBeNull();
+                expect(el.getAttribute('data-bar')).toEqual('bar');
+                expect(el.getAttribute('data-baz')).toEqual('baz');
 
                 patch(container, () =>
                     render({
                         'data-bar': 'bar',
                     })
                 );
-                expect(el.getAttribute('data-foo')).to.equal(null);
-                expect(el.getAttribute('data-bar')).to.equal('bar');
-                expect(el.getAttribute('data-baz')).to.equal(null);
+                expect(el.getAttribute('data-foo')).toBeNull();
+                expect(el.getAttribute('data-bar')).toEqual('bar');
+                expect(el.getAttribute('data-baz')).toBeNull();
             });
 
             it('should keep attribute that is backwards up then kept', () => {
@@ -202,9 +201,9 @@ describe('attribute updates', () => {
                 );
                 const el = container.childNodes[0];
 
-                expect(el.getAttribute('data-foo')).to.equal('foo');
-                expect(el.getAttribute('data-bar')).to.equal('bar');
-                expect(el.getAttribute('data-baz')).to.equal('baz');
+                expect(el.getAttribute('data-foo')).toEqual('foo');
+                expect(el.getAttribute('data-bar')).toEqual('bar');
+                expect(el.getAttribute('data-baz')).toEqual('baz');
 
                 patch(container, () =>
                     render({
@@ -212,9 +211,9 @@ describe('attribute updates', () => {
                         'data-bar': 'bar',
                     })
                 );
-                expect(el.getAttribute('data-foo')).to.equal('foo');
-                expect(el.getAttribute('data-bar')).to.equal('bar');
-                expect(el.getAttribute('data-baz')).to.equal(null);
+                expect(el.getAttribute('data-foo')).toEqual('foo');
+                expect(el.getAttribute('data-bar')).toEqual('bar');
+                expect(el.getAttribute('data-baz')).toBeNull();
             });
         });
 
@@ -228,8 +227,8 @@ describe('attribute updates', () => {
             patch(container, () => render({}));
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-foo')).to.equal(null);
-            expect(el.getAttribute('data-bar')).to.equal(null);
+            expect(el.getAttribute('data-foo')).toBeNull();
+            expect(el.getAttribute('data-bar')).toBeNull();
         });
     });
 
@@ -254,7 +253,7 @@ describe('attribute updates', () => {
             {}
         );
         el.click();
-        expect(count).to.equal(1);
+        expect(count).toEqual(1);
         window.handler = old;
     });
 
@@ -266,7 +265,7 @@ describe('attribute updates', () => {
             });
             const el = container.childNodes[0];
 
-            expect(el.hasAttribute('fn')).to.be.false;
+            expect(el.hasAttribute('fn')).toBeFalsy();
         });
 
         it('should be set on the node', () => {
@@ -276,7 +275,7 @@ describe('attribute updates', () => {
             });
             const el = container.childNodes[0];
 
-            expect(el.fn).to.equal(fn);
+            expect(el.fn).toEqual(fn);
         });
 
         it('should remove event listeners', () => {
@@ -299,7 +298,7 @@ describe('attribute updates', () => {
                 {}
             );
             el.click();
-            expect(count).to.equal(1);
+            expect(count).toEqual(1);
         });
     });
 
@@ -311,7 +310,7 @@ describe('attribute updates', () => {
             });
             const el = container.childNodes[0];
 
-            expect(el.hasAttribute('obj')).to.be.false;
+            expect(el.hasAttribute('obj')).toBeFalsy();
         });
 
         it('should be set on the node', () => {
@@ -321,7 +320,7 @@ describe('attribute updates', () => {
             });
             const el = container.childNodes[0];
 
-            expect(el.obj).to.equal(obj);
+            expect(el.obj).toEqual(obj);
         });
     });
 
@@ -332,7 +331,7 @@ describe('attribute updates', () => {
             });
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('class')).to.equal('foo');
+            expect(el.getAttribute('class')).toEqual('foo');
         });
 
         it('should apply the correct namespace for namespaced SVG attributes', () => {
@@ -344,7 +343,7 @@ describe('attribute updates', () => {
             const el = container.childNodes[0].childNodes[0];
             expect(
                 el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
-            ).to.equal('#foo');
+            ).toEqual('#foo');
         });
 
         it('should remove namespaced SVG attributes', () => {
@@ -359,8 +358,9 @@ describe('attribute updates', () => {
                 elementClose('svg');
             });
             const el = container.childNodes[0].childNodes[0];
-            expect(el.hasAttributeNS('http://www.w3.org/1999/xlink', 'href')).to
-                .be.false;
+            expect(
+                el.hasAttributeNS('http://www.w3.org/1999/xlink', 'href')
+            ).toBeFalsy();
         });
     });
 
@@ -375,7 +375,7 @@ describe('attribute updates', () => {
             el.setAttribute('data-foo', 'bar');
             patch(container, render);
 
-            expect(el.getAttribute('data-foo')).to.equal('bar');
+            expect(el.getAttribute('data-foo')).toEqual('bar');
         });
 
         it('should be preserved when importing DOM', () => {
@@ -386,7 +386,7 @@ describe('attribute updates', () => {
             el.setAttribute('data-foo', 'bar');
             patch(container, render);
 
-            expect(el.getAttribute('data-foo')).to.equal('bar');
+            expect(el.getAttribute('data-foo')).toEqual('bar');
         });
     });
 
@@ -408,14 +408,14 @@ describe('attribute updates', () => {
             patch(container, render);
             let child = container.childNodes[0];
 
-            expect(child.getAttribute('tabindex')).to.equal('0');
-            expect(child.getAttribute('class')).to.equal('bar');
+            expect(child.getAttribute('tabindex')).toEqual('0');
+            expect(child.getAttribute('class')).toEqual('bar');
 
             patch(container, render);
             child = container.childNodes[0];
 
-            expect(child.getAttribute('tabindex')).to.equal('0');
-            expect(child.getAttribute('class')).to.equal('bar');
+            expect(child.getAttribute('tabindex')).toEqual('0');
+            expect(child.getAttribute('class')).toEqual('bar');
         });
 
         it('should remove attributes', () => {
@@ -425,14 +425,14 @@ describe('attribute updates', () => {
             patch(container, render, { attr: 'data-foo' });
             const child = container.childNodes[0];
 
-            expect(child.hasAttribute('tabindex')).to.false;
-            expect(child.hasAttribute('class')).to.true;
-            expect(child.getAttribute('data-foo')).to.equal('bar');
+            expect(child.hasAttribute('tabindex')).toBeFalsy();
+            expect(child.hasAttribute('class')).toBeTruthy();
+            expect(child.getAttribute('data-foo')).toEqual('bar');
 
             patch(container, render, { attr: 'data-bar' });
-            expect(child.hasAttribute('tabindex')).to.false;
-            expect(child.hasAttribute('data-foo')).to.false;
-            expect(child.getAttribute('data-bar')).to.equal('bar');
+            expect(child.hasAttribute('tabindex')).toBeFalsy();
+            expect(child.hasAttribute('data-foo')).toBeFalsy();
+            expect(child.getAttribute('data-bar')).toEqual('bar');
         });
 
         it('should persist statics', () => {
@@ -443,10 +443,10 @@ describe('attribute updates', () => {
             patch(container, render, 'bar');
             const child = container.childNodes[0];
 
-            expect(child.getAttribute('data-foo')).to.equal('bar');
+            expect(child.getAttribute('data-foo')).toEqual('bar');
 
             patch(container, render, 'baz');
-            expect(child.getAttribute('data-foo')).to.equal('bar');
+            expect(child.getAttribute('data-foo')).toEqual('bar');
         });
 
         it('should persist statics when patching a parent', () => {
@@ -463,12 +463,12 @@ describe('attribute updates', () => {
             patch(child, render, 'bar');
             const grandChild = child.childNodes[0];
 
-            expect(grandChild.getAttribute('data-foo')).to.equal('bar');
+            expect(grandChild.getAttribute('data-foo')).toEqual('bar');
 
             patch(container, renderParent, 'baz');
 
-            expect(child.hasAttribute('tabindex')).to.false;
-            expect(grandChild.getAttribute('data-foo')).to.equal('bar');
+            expect(child.hasAttribute('tabindex')).toBeFalsy();
+            expect(grandChild.getAttribute('data-foo')).toEqual('bar');
         });
     });
 });

--- a/packages/melody-idom/__tests__/ComponentSpec.ts
+++ b/packages/melody-idom/__tests__/ComponentSpec.ts
@@ -86,7 +86,7 @@ describe('component', function() {
         expect(el.innerHTML).toEqual('<m-placeholder></m-placeholder>');
         run();
         expect(el.innerHTML).toEqual('<div>Hello</div>');
-        expect(unmounted).toEqual(false);
+        expect(unmounted).toBeFalsy();
     });
 
     it('should mount the component', function() {
@@ -110,7 +110,7 @@ describe('component', function() {
             { text: 'Hello' }
         );
         run();
-        expect(notified).toEqual(true);
+        expect(notified).toBeTruthy();
     });
 
     it('should invoke componentWillUnmount when the component is removed', function() {
@@ -130,7 +130,7 @@ describe('component', function() {
             },
             { text: 'Hello' }
         );
-        expect(unmounted).toEqual(true);
+        expect(unmounted).toBeTruthy();
     });
 
     it('should render in multiple stages', function() {

--- a/packages/melody-idom/__tests__/ConditionalRenderingSpec.ts
+++ b/packages/melody-idom/__tests__/ConditionalRenderingSpec.ts
@@ -16,7 +16,6 @@
  */
 
 import { patch, elementOpen, elementClose, elementVoid } from '../src';
-import { expect } from 'chai';
 
 describe('conditional rendering', () => {
     let container;
@@ -55,11 +54,11 @@ describe('conditional rendering', () => {
             patch(container, () => render(false));
             const outer = container.childNodes[0];
 
-            expect(outer.childNodes).to.have.length(2);
-            expect(outer.childNodes[0].id).to.equal('one');
-            expect(outer.childNodes[0].tagName).to.equal('DIV');
-            expect(outer.childNodes[1].id).to.equal('two');
-            expect(outer.childNodes[1].tagName).to.equal('SPAN');
+            expect(outer.childNodes).toHaveLength(2);
+            expect(outer.childNodes[0].id).toEqual('one');
+            expect(outer.childNodes[0].tagName).toEqual('DIV');
+            expect(outer.childNodes[1].id).toEqual('two');
+            expect(outer.childNodes[1].tagName).toEqual('SPAN');
         });
 
         it('should render when the condition becomes true', () => {
@@ -67,15 +66,15 @@ describe('conditional rendering', () => {
             patch(container, () => render(true));
             const outer = container.childNodes[0];
 
-            expect(outer.childNodes).to.have.length(4);
-            expect(outer.childNodes[0].id).to.equal('one');
-            expect(outer.childNodes[0].tagName).to.equal('DIV');
-            expect(outer.childNodes[1].id).to.equal('conditional-one');
-            expect(outer.childNodes[1].tagName).to.equal('DIV');
-            expect(outer.childNodes[2].id).to.equal('conditional-two');
-            expect(outer.childNodes[2].tagName).to.equal('DIV');
-            expect(outer.childNodes[3].id).to.equal('two');
-            expect(outer.childNodes[3].tagName).to.equal('SPAN');
+            expect(outer.childNodes).toHaveLength(4);
+            expect(outer.childNodes[0].id).toEqual('one');
+            expect(outer.childNodes[0].tagName).toEqual('DIV');
+            expect(outer.childNodes[1].id).toEqual('conditional-one');
+            expect(outer.childNodes[1].tagName).toEqual('DIV');
+            expect(outer.childNodes[2].id).toEqual('conditional-two');
+            expect(outer.childNodes[2].tagName).toEqual('DIV');
+            expect(outer.childNodes[3].id).toEqual('two');
+            expect(outer.childNodes[3].tagName).toEqual('SPAN');
         });
     });
 
@@ -102,7 +101,7 @@ describe('conditional rendering', () => {
             patch(container, () => render(false));
             const outer = container.childNodes[0];
 
-            expect(outer.childNodes).to.have.length(0);
+            expect(outer.childNodes).toHaveLength(0);
         });
     });
 
@@ -134,12 +133,12 @@ describe('conditional rendering', () => {
             patch(container, () => render(false));
             const outer = container.childNodes[0];
 
-            expect(outer.childNodes).to.have.length(2);
-            expect(outer.childNodes[0].id).to.equal('one');
-            expect(outer.childNodes[0].tagName).to.equal('DIV');
-            expect(outer.childNodes[1].id).to.equal('two');
-            expect(outer.childNodes[1].tagName).to.equal('SPAN');
-            expect(outer.childNodes[1].children.length).to.equal(0);
+            expect(outer.childNodes).toHaveLength(2);
+            expect(outer.childNodes[0].id).toEqual('one');
+            expect(outer.childNodes[0].tagName).toEqual('DIV');
+            expect(outer.childNodes[1].id).toEqual('two');
+            expect(outer.childNodes[1].tagName).toEqual('SPAN');
+            expect(outer.childNodes[1].children.length).toEqual(0);
         });
 
         it('should strip attributes when a conflicting node is re-used', () => {
@@ -147,7 +146,7 @@ describe('conditional rendering', () => {
             patch(container, () => render(false));
             const outer = container.childNodes[0];
 
-            expect(outer.childNodes[1].getAttribute('data-foo')).to.be.null;
+            expect(outer.childNodes[1].getAttribute('data-foo')).toBeNull();
         });
     });
 });

--- a/packages/melody-idom/__tests__/CurrentElementSpec.ts
+++ b/packages/melody-idom/__tests__/CurrentElementSpec.ts
@@ -24,7 +24,6 @@ import {
     elementVoid,
     currentElement,
 } from '../src';
-import { expect } from 'chai';
 
 describe('currentElement', () => {
     let container;
@@ -46,7 +45,7 @@ describe('currentElement', () => {
             el = currentElement();
             elementClose('div');
         });
-        expect(el).to.equal(container.childNodes[0]);
+        expect(el).toEqual(container.childNodes[0]);
     });
 
     it('should return the element from elementOpenEnd', () => {
@@ -57,7 +56,7 @@ describe('currentElement', () => {
             elementClose('div');
         });
 
-        expect(el).to.equal(container.childNodes[0]);
+        expect(el).toEqual(container.childNodes[0]);
     });
 
     it('should return the parent after elementClose', () => {
@@ -67,7 +66,7 @@ describe('currentElement', () => {
             el = currentElement();
         });
 
-        expect(el).to.equal(container);
+        expect(el).toEqual(container);
     });
 
     it('should return the parent after elementVoid', () => {
@@ -76,16 +75,17 @@ describe('currentElement', () => {
             el = currentElement();
         });
 
-        expect(el).to.equal(container);
+        expect(el).toEqual(container);
     });
 
     it('should throw an error if not patching', () => {
-        expect(currentElement).to.throw(
-            'Cannot call currentElement() unless in patch',
-        );
+        const error = 'Cannot call currentElement() unless in patch';
+        expect(currentElement).toThrowError(new Error(error));
     });
 
     it('should throw an error if inside virtual attributes element', () => {
+        const error =
+            'currentElement() can not be called between elementOpenStart() and elementOpenEnd().';
         expect(() => {
             patch(container, () => {
                 elementOpenStart('div');
@@ -93,8 +93,6 @@ describe('currentElement', () => {
                 elementOpenEnd('div');
                 elementClose('div');
             });
-        }).to.throw(
-            'currentElement() can not be called between elementOpenStart() and elementOpenEnd().',
-        );
+        }).toThrowError(new Error(error));
     });
 });

--- a/packages/melody-idom/__tests__/ElementCreationSpec.ts
+++ b/packages/melody-idom/__tests__/ElementCreationSpec.ts
@@ -23,12 +23,9 @@ import {
     elementClose,
     elementVoid,
 } from '../src';
-import sinon from 'sinon';
-import { expect } from 'chai';
 
 describe('element creation', () => {
     let container;
-    let sandbox = sinon.sandbox.create();
 
     beforeEach(() => {
         container = document.createElement('div');
@@ -36,7 +33,6 @@ describe('element creation', () => {
     });
 
     afterEach(() => {
-        sandbox.restore();
         document.body.removeChild(container);
     });
 
@@ -59,7 +55,7 @@ describe('element creation', () => {
                     'data-foo',
                     'Hello',
                     'data-bar',
-                    'World',
+                    'World'
                 );
             });
 
@@ -67,18 +63,18 @@ describe('element creation', () => {
         });
 
         it('should render with the specified tag', () => {
-            expect(el.tagName).to.equal('DIV');
+            expect(el.tagName).toEqual('DIV');
         });
 
         it('should render with static attributes', () => {
-            expect(el.id).to.equal('someId');
-            expect(el.className).to.equal('someClass');
-            expect(el.getAttribute('data-custom')).to.equal('custom');
+            expect(el.id).toEqual('someId');
+            expect(el.className).toEqual('someClass');
+            expect(el.getAttribute('data-custom')).toEqual('custom');
         });
 
         it('should render with dynamic attributes', () => {
-            expect(el.getAttribute('data-foo')).to.equal('Hello');
-            expect(el.getAttribute('data-bar')).to.equal('World');
+            expect(el.getAttribute('data-foo')).toEqual('Hello');
+            expect(el.getAttribute('data-bar')).toEqual('World');
         });
 
         describe('should return DOM node', () => {
@@ -92,7 +88,7 @@ describe('element creation', () => {
                     elementClose('div');
                 });
 
-                expect(el).to.equal(container.childNodes[0]);
+                expect(el).toEqual(container.childNodes[0]);
             });
 
             it('from elementClose', () => {
@@ -101,7 +97,7 @@ describe('element creation', () => {
                     el = elementClose('div');
                 });
 
-                expect(el).to.equal(container.childNodes[0]);
+                expect(el).toEqual(container.childNodes[0]);
             });
 
             it('from elementVoid', () => {
@@ -109,7 +105,7 @@ describe('element creation', () => {
                     el = elementVoid('div');
                 });
 
-                expect(el).to.equal(container.childNodes[0]);
+                expect(el).toEqual(container.childNodes[0]);
             });
 
             it('from elementOpenEnd', () => {
@@ -119,7 +115,7 @@ describe('element creation', () => {
                     elementClose('div');
                 });
 
-                expect(el).to.equal(container.childNodes[0]);
+                expect(el).toEqual(container.childNodes[0]);
             });
         });
     });
@@ -129,7 +125,7 @@ describe('element creation', () => {
             elementVoid('div', null, null, 'id', 'test');
         });
         const el = container.childNodes[0];
-        expect(el.id).to.equal('test');
+        expect(el.id).toEqual('test');
     });
 
     describe('for HTML elements', () => {
@@ -139,14 +135,15 @@ describe('element creation', () => {
             });
 
             const el = container.childNodes[0];
-            expect(el.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
+            expect(el.namespaceURI).toEqual('http://www.w3.org/1999/xhtml');
         });
 
         it('should use createElement if no namespace has been specified', () => {
             let doc = container.ownerDocument;
             let div = doc.createElement('div');
             let el;
-            sandbox.stub(doc, 'createElement').returns(div);
+
+            const spy = jest.spyOn(doc, 'createElement');
 
             patch(container, () => {
                 elementOpen('svg');
@@ -156,8 +153,8 @@ describe('element creation', () => {
                 elementClose('svg');
             });
 
-            expect(el.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
-            expect(doc.createElement).to.have.been.calledOnce;
+            expect(el.namespaceURI).toEqual('http://www.w3.org/1999/xhtml');
+            expect(spy).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -178,27 +175,27 @@ describe('element creation', () => {
 
         it('should create svgs in the svg namespace', () => {
             const el = container.querySelector('svg');
-            expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+            expect(el.namespaceURI).toEqual('http://www.w3.org/2000/svg');
         });
 
         it('should create descendants of svgs in the svg namespace', () => {
             const el = container.querySelector('circle');
-            expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+            expect(el.namespaceURI).toEqual('http://www.w3.org/2000/svg');
         });
 
         it('should have the svg namespace for foreignObjects', () => {
             const el = container.querySelector('svg').childNodes[1];
-            expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+            expect(el.namespaceURI).toEqual('http://www.w3.org/2000/svg');
         });
 
         it('should revert to the xhtml namespace when encounering a foreignObject', () => {
             const el = container.querySelector('p');
-            expect(el.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
+            expect(el.namespaceURI).toEqual('http://www.w3.org/1999/xhtml');
         });
 
         it('should reset to the previous namespace after exiting a forignObject', () => {
             const el = container.querySelector('path');
-            expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+            expect(el.namespaceURI).toEqual('http://www.w3.org/2000/svg');
         });
 
         it('should create children in the svg namespace when patching an svg', () => {
@@ -208,7 +205,7 @@ describe('element creation', () => {
             });
 
             const el = svg.querySelector('rect');
-            expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+            expect(el.namespaceURI).toEqual('http://www.w3.org/2000/svg');
         });
     });
 });

--- a/packages/melody-idom/__tests__/FormattersSpec.ts
+++ b/packages/melody-idom/__tests__/FormattersSpec.ts
@@ -16,11 +16,6 @@
  */
 
 import { patch, text } from '../src';
-import sinon from 'sinon';
-import chai from 'chai';
-import sinonChai from 'sinon-chai';
-chai.use(sinonChai);
-import { expect } from 'chai';
 
 describe('formatters', () => {
     let container;
@@ -49,7 +44,7 @@ describe('formatters', () => {
             });
             const node = container.childNodes[0];
 
-            expect(node.textContent).to.equal("'ello world!");
+            expect(node.textContent).toEqual("'ello world!");
         });
     });
 
@@ -61,18 +56,21 @@ describe('formatters', () => {
         }
 
         beforeEach(() => {
-            stub = sinon.stub();
-            stub.onFirstCall().returns('stubValueOne');
-            stub.onSecondCall().returns('stubValueTwo');
+            stub = jest
+                .fn()
+                .mockReturnValue('default')
+                .mockReturnValueOnce('stubValueOne')
+                .mockReturnValueOnce('stubValueTwo');
         });
 
         it('should not call the formatter for unchanged values', () => {
             patch(container, () => render('hello'));
             patch(container, () => render('hello'));
+
             const node = container.childNodes[0];
 
-            expect(node.textContent).to.equal('stubValueOne');
-            expect(stub).to.have.been.calledOnce;
+            expect(node.textContent).toEqual('stubValueOne');
+            expect(stub).toHaveBeenCalledTimes(1);
         });
 
         it('should call the formatter when the value changes', () => {
@@ -80,15 +78,16 @@ describe('formatters', () => {
             patch(container, () => render('world'));
             const node = container.childNodes[0];
 
-            expect(node.textContent).to.equal('stubValueTwo');
-            expect(stub).to.have.been.calledTwice;
+            expect(node.textContent).toEqual('stubValueTwo');
+            expect(stub).toHaveBeenCalledTimes(2);
         });
     });
 
     it('should not leak the arguments object', () => {
-        const stub = sinon.stub().returns('value');
-        patch(container, () => text('value', stub));
+        const spy = jest.fn(() => 'value');
 
-        expect(stub).to.have.been.calledOn(undefined);
+        patch(container, () => text('value', spy));
+
+        expect(spy).toHaveBeenCalledWith('value');
     });
 });

--- a/packages/melody-idom/__tests__/ImportElementSpec.ts
+++ b/packages/melody-idom/__tests__/ImportElementSpec.ts
@@ -17,12 +17,9 @@
 
 import { patch, elementVoid, elementOpen, elementClose } from '../src';
 import { importNode } from '../built/node_data';
-import sinon from 'sinon';
-import { expect } from 'chai';
 
 describe('importing element', () => {
     let container;
-    let sandbox = sinon.sandbox.create();
 
     beforeEach(() => {
         container = document.createElement('div');
@@ -30,7 +27,6 @@ describe('importing element', () => {
     });
 
     afterEach(() => {
-        sandbox.restore();
         document.body.removeChild(container);
     });
 
@@ -41,7 +37,7 @@ describe('importing element', () => {
 
             const el = container.firstChild;
             patch(container, () => elementVoid('div'));
-            expect(container.firstChild).to.equal(el);
+            expect(container.firstChild).toEqual(el);
         });
 
         it('handles odd nodeName capitalization', () => {
@@ -50,7 +46,7 @@ describe('importing element', () => {
 
             const el = container.firstChild;
             patch(container, () => elementVoid('div'));
-            expect(container.firstChild).to.equal(el);
+            expect(container.firstChild).toEqual(el);
         });
     });
 
@@ -65,7 +61,7 @@ describe('importing element', () => {
                 elementVoid('foreignObject');
                 elementClose('svg');
             });
-            expect(container.firstChild.firstChild).to.equal(foreign);
+            expect(container.firstChild.firstChild).toEqual(foreign);
         });
 
         it('handles odd nodeName capitalization', () => {
@@ -78,7 +74,7 @@ describe('importing element', () => {
                 elementVoid('foreignObject');
                 elementClose('svg');
             });
-            expect(container.firstChild.firstChild).to.equal(foreign);
+            expect(container.firstChild.firstChild).toEqual(foreign);
         });
     });
 });

--- a/packages/melody-idom/__tests__/KeyedItemsSpec.ts
+++ b/packages/melody-idom/__tests__/KeyedItemsSpec.ts
@@ -23,7 +23,6 @@ import {
     currentElement,
     skip,
 } from '../src';
-import { expect } from 'chai';
 
 const BROWSER_SUPPORTS_SHADOW_DOM = 'ShadowRoot' in window;
 const attachShadow = function(el) {
@@ -60,8 +59,8 @@ describe('rendering with keys', () => {
         items.unshift({ key: null });
         patch(container, () => render(items));
 
-        expect(container.childNodes).to.have.length(2);
-        expect(container.childNodes[0]).to.not.equal(keyedNode);
+        expect(container.childNodes).toHaveLength(2);
+        expect(container.childNodes[0]).not.toEqual(keyedNode);
     });
 
     it('should not modify DOM nodes with falsey keys', () => {
@@ -73,7 +72,7 @@ describe('rendering with keys', () => {
 
         patch(container, () => render(items));
 
-        expect(slice.call(container.childNodes)).to.deep.equal(nodes);
+        expect(slice.call(container.childNodes)).toEqual(nodes);
     });
 
     it('should not modify the DOM nodes when inserting', () => {
@@ -86,12 +85,12 @@ describe('rendering with keys', () => {
         items.splice(1, 0, { key: 'one-point-five' });
         patch(container, () => render(items));
 
-        expect(container.childNodes).to.have.length(3);
-        expect(container.childNodes[0]).to.equal(firstNode);
-        expect(container.childNodes[0].id).to.equal('one');
-        expect(container.childNodes[1].id).to.equal('one-point-five');
-        expect(container.childNodes[2]).to.equal(secondNode);
-        expect(container.childNodes[2].id).to.equal('two');
+        expect(container.childNodes).toHaveLength(3);
+        expect(container.childNodes[0]).toEqual(firstNode);
+        expect(container.childNodes[0].id).toEqual('one');
+        expect(container.childNodes[1].id).toEqual('one-point-five');
+        expect(container.childNodes[2]).toEqual(secondNode);
+        expect(container.childNodes[2].id).toEqual('two');
     });
 
     it('should not modify the DOM nodes when removing', () => {
@@ -104,11 +103,11 @@ describe('rendering with keys', () => {
         items.splice(1, 1);
         patch(container, () => render(items));
 
-        expect(container.childNodes).to.have.length(2);
-        expect(container.childNodes[0]).to.equal(firstNode);
-        expect(container.childNodes[0].id).to.equal('one');
-        expect(container.childNodes[1]).to.equal(thirdNode);
-        expect(container.childNodes[1].id).to.equal('three');
+        expect(container.childNodes).toHaveLength(2);
+        expect(container.childNodes[0]).toEqual(firstNode);
+        expect(container.childNodes[0].id).toEqual('one');
+        expect(container.childNodes[1]).toEqual(thirdNode);
+        expect(container.childNodes[1].id).toEqual('three');
     });
 
     it('should not modify the DOM nodes when re-ordering', () => {
@@ -123,20 +122,20 @@ describe('rendering with keys', () => {
         items.push({ key: 'two' });
         patch(container, () => render(items));
 
-        expect(container.childNodes).to.have.length(3);
-        expect(container.childNodes[0]).to.equal(firstNode);
-        expect(container.childNodes[0].id).to.equal('one');
-        expect(container.childNodes[1]).to.equal(thirdNode);
-        expect(container.childNodes[1].id).to.equal('three');
-        expect(container.childNodes[2]).to.equal(secondNode);
-        expect(container.childNodes[2].id).to.equal('two');
+        expect(container.childNodes).toHaveLength(3);
+        expect(container.childNodes[0]).toEqual(firstNode);
+        expect(container.childNodes[0].id).toEqual('one');
+        expect(container.childNodes[1]).toEqual(thirdNode);
+        expect(container.childNodes[1].id).toEqual('three');
+        expect(container.childNodes[2]).toEqual(secondNode);
+        expect(container.childNodes[2].id).toEqual('two');
     });
 
     it('should avoid collisions with Object.prototype', () => {
         const items = [{ key: 'hasOwnProperty' }];
 
         patch(container, () => render(items));
-        expect(container.childNodes).to.have.length(1);
+        expect(container.childNodes).toHaveLength(1);
     });
 
     it("should not reuse dom node when nodeName doesn't match", () => {
@@ -149,9 +148,9 @@ describe('rendering with keys', () => {
 
         patch(container, render, 'span');
         const newNode = container.childNodes[0];
-        expect(newNode).not.to.equal(firstNode);
-        expect(newNode.nodeName).to.equal('SPAN');
-        expect(firstNode.parentNode).to.equal(null);
+        expect(newNode).not.toEqual(firstNode);
+        expect(newNode.nodeName).toEqual('SPAN');
+        expect(firstNode.parentNode).toBeNull();
     });
 
     it('should preserve nodes already in the DOM', () => {
@@ -168,7 +167,7 @@ describe('rendering with keys', () => {
 
         patch(container, render);
 
-        expect(container.firstChild).to.equal(keyedDiv);
+        expect(container.firstChild).toEqual(keyedDiv);
     });
 
     it('should remove keyed nodes whose element type changes', () => {
@@ -184,7 +183,7 @@ describe('rendering with keys', () => {
 
         patch(container, render);
 
-        expect(container.innerHTML).to.equal('<div></div><div></div>');
+        expect(container.innerHTML).toEqual('<div></div><div></div>');
     });
 
     describe('an item with focus', () => {
@@ -207,7 +206,7 @@ describe('rendering with keys', () => {
             items.unshift({ key: 'zero' });
             patch(container, () => render(items));
 
-            expect(document.activeElement).to.equal(focusNode);
+            expect(document.activeElement).toEqual(focusNode);
         });
 
         it('should retain focus when moving up in DOM order', () => {
@@ -220,7 +219,7 @@ describe('rendering with keys', () => {
             items.unshift(items.pop());
             patch(container, () => render(items));
 
-            expect(document.activeElement).to.equal(focusNode);
+            expect(document.activeElement).toEqual(focusNode);
         });
 
         it('should retain focus when moving down in DOM order', () => {
@@ -233,7 +232,7 @@ describe('rendering with keys', () => {
             items.push(items.shift());
             patch(container, () => render(items));
 
-            expect(document.activeElement).to.equal(focusNode);
+            expect(document.activeElement).toEqual(focusNode);
         });
 
         it('should retain focus when doing a nested patch', () => {
@@ -260,7 +259,7 @@ describe('rendering with keys', () => {
             items.unshift(items.pop());
             patch(container, () => render(items));
 
-            expect(document.activeElement).to.equal(focusNode);
+            expect(document.activeElement).toEqual(focusNode);
         });
 
         if (BROWSER_SUPPORTS_SHADOW_DOM) {
@@ -275,8 +274,8 @@ describe('rendering with keys', () => {
                 items.unshift({ key: 'zero' });
                 patch(shadowRoot, () => render(items));
 
-                expect(shadowRoot.activeElement).to.equal(focusNode);
-                expect(document.activeElement).to.equal(container);
+                expect(shadowRoot.activeElement).toEqual(focusNode);
+                expect(document.activeElement).toEqual(container);
             });
 
             it('should retain focus when patching outside a ShadowRoot', () => {
@@ -284,7 +283,7 @@ describe('rendering with keys', () => {
 
                 const shadowRoot = attachShadow(container);
                 const shadowEl = shadowRoot.appendChild(
-                    document.createElement('div'),
+                    document.createElement('div')
                 );
                 shadowEl.tabIndex = -1;
                 shadowEl.focus();
@@ -292,7 +291,7 @@ describe('rendering with keys', () => {
                 items.unshift({ key: 'zero' });
                 patch(container, () => render(items));
 
-                expect(shadowRoot.activeElement).to.equal(shadowEl);
+                expect(shadowRoot.activeElement).toEqual(shadowEl);
             });
         }
     });

--- a/packages/melody-idom/__tests__/PatchInnerSpec.ts
+++ b/packages/melody-idom/__tests__/PatchInnerSpec.ts
@@ -25,7 +25,6 @@ import {
     elementVoid,
     text,
 } from '../src';
-import { expect } from 'chai';
 
 describe("patching an element's children", () => {
     let container;
@@ -56,7 +55,7 @@ describe("patching an element's children", () => {
             patchInner(container, render);
             const child = container.childNodes[0];
 
-            expect(child).to.equal(div);
+            expect(child).toEqual(div);
         });
 
         describe('should return DOM node', () => {
@@ -68,7 +67,7 @@ describe("patching an element's children", () => {
                     elementClose('div');
                 });
 
-                expect(node).to.equal(div);
+                expect(node).toEqual(div);
             });
 
             it('from elementClose', () => {
@@ -77,7 +76,7 @@ describe("patching an element's children", () => {
                     node = elementClose('div');
                 });
 
-                expect(node).to.equal(div);
+                expect(node).toEqual(div);
             });
 
             it('from elementVoid', () => {
@@ -85,7 +84,7 @@ describe("patching an element's children", () => {
                     node = elementVoid('div');
                 });
 
-                expect(node).to.equal(div);
+                expect(node).toEqual(div);
             });
 
             it('from elementOpenEnd', () => {
@@ -95,7 +94,7 @@ describe("patching an element's children", () => {
                     elementClose('div');
                 });
 
-                expect(node).to.equal(div);
+                expect(node).toEqual(div);
             });
 
             it('from elementOpen when Node.prototype.contains not available', () => {
@@ -106,7 +105,7 @@ describe("patching an element's children", () => {
                     elementClose('div');
                 });
 
-                expect(node).to.equal(div);
+                expect(node).toEqual(div);
             });
         });
     });
@@ -128,8 +127,8 @@ describe("patching an element's children", () => {
 
         patchInner(containerOne, renderOne);
 
-        expect(containerOne.textContent).to.equal('hello');
-        expect(containerTwo.textContent).to.equal('foobar');
+        expect(containerOne.textContent).toEqual('hello');
+        expect(containerTwo.textContent).toEqual('foobar');
     });
 
     it('should pass third argument to render function', () => {
@@ -139,7 +138,7 @@ describe("patching an element's children", () => {
 
         patchInner(container, render, 'foobar');
 
-        expect(container.textContent).to.equal('foobar');
+        expect(container.textContent).toEqual('foobar');
     });
 
     it('should patch a detached node', () => {
@@ -150,15 +149,16 @@ describe("patching an element's children", () => {
 
         patchInner(container, render);
 
-        expect(container.firstChild.tagName).to.equal('SPAN');
+        expect(container.firstChild.tagName).toEqual('SPAN');
     });
 
     it('should throw when an element is unclosed', function() {
+        const error = 'One or more tags were not closed:\ndiv';
         expect(() => {
             patch(container, () => {
                 elementOpen('div');
             });
-        }).to.throw('One or more tags were not closed:\ndiv');
+        }).toThrowError(error);
     });
 });
 
@@ -171,22 +171,23 @@ describe('patching a documentFragment', function() {
             elementClose('div');
         });
 
-        expect(frag.childNodes[0].id).to.equal('aDiv');
+        expect(frag.childNodes[0].id).toEqual('aDiv');
     });
 });
 
 describe('when patching an non existing element', function() {
     it('should throw an error', function() {
+        const error = 'Patch invoked without an element';
         expect(() =>
             patchInner(null, function() {
-                expect(false).to.be.true;
+                expect(false).toBeTruthy();
             })
-        ).to.throw('Patch invoked without an element');
+        ).toThrowError(error);
     });
 });
 
 describe('patch', () => {
     it('should alias patchInner', () => {
-        expect(patch).to.equal(patchInner);
+        expect(patch).toEqual(patchInner);
     });
 });

--- a/packages/melody-idom/__tests__/PatchOuterSpec.ts
+++ b/packages/melody-idom/__tests__/PatchOuterSpec.ts
@@ -22,7 +22,6 @@ import {
     elementVoid,
     text,
 } from '../src';
-import { expect } from 'chai';
 
 describe('patching an element', () => {
     let container;
@@ -43,7 +42,7 @@ describe('patching an element', () => {
 
         patchOuter(container, render);
 
-        expect(container.getAttribute('tabindex')).to.equal('0');
+        expect(container.getAttribute('tabindex')).toEqual('0');
     });
 
     it('should return the DOM node', () => {
@@ -53,7 +52,7 @@ describe('patching an element', () => {
 
         const result = patchOuter(container, render);
 
-        expect(result).to.equal(container);
+        expect(result).toEqual(container);
     });
 
     it('should update children', () => {
@@ -65,7 +64,7 @@ describe('patching an element', () => {
 
         patchOuter(container, render);
 
-        expect(container.firstChild.tagName).to.equal('SPAN');
+        expect(container.firstChild.tagName).toEqual('SPAN');
     });
 
     it('should be re-entrant', function() {
@@ -87,8 +86,8 @@ describe('patching an element', () => {
 
         patchOuter(containerOne, renderOne);
 
-        expect(containerOne.textContent).to.equal('hello');
-        expect(containerTwo.textContent).to.equal('foobar');
+        expect(containerOne.textContent).toEqual('hello');
+        expect(containerTwo.textContent).toEqual('foobar');
     });
 
     it('should pass third argument to render function', () => {
@@ -100,7 +99,7 @@ describe('patching an element', () => {
 
         patchOuter(container, render, 'foobar');
 
-        expect(container.textContent).to.equal('foobar');
+        expect(container.textContent).toEqual('foobar');
     });
 
     it('should patch a detached node', () => {
@@ -113,7 +112,7 @@ describe('patching an element', () => {
 
         patchOuter(container, render);
 
-        expect(container.firstChild.tagName).to.equal('SPAN');
+        expect(container.firstChild.tagName).toEqual('SPAN');
     });
 
     describe('with an empty patch', () => {
@@ -127,11 +126,11 @@ describe('patching an element', () => {
         });
 
         it('should remove the DOM node on an empty patch', () => {
-            expect(container.firstChild).to.be.null;
+            expect(container.firstChild).toBeNull();
         });
 
         it('should remove the DOM node on an empty patch', () => {
-            expect(result).to.be.null;
+            expect(result).toBeNull();
         });
     });
 
@@ -153,12 +152,12 @@ describe('patching an element', () => {
             });
 
             it('should replace the DOM node', () => {
-                expect(container.children).to.have.length(1);
-                expect(container.firstChild).to.equal(span);
+                expect(container.children).toHaveLength(1);
+                expect(container.firstChild).toEqual(span);
             });
 
             it('should return the new DOM node', () => {
-                expect(result).to.equal(span);
+                expect(result).toEqual(span);
             });
         });
 
@@ -177,22 +176,22 @@ describe('patching an element', () => {
             it('should replace the DOM node when a key changes', () => {
                 div.setAttribute('key', 'key0');
                 patchOuter(div, render, { tag: 'span', key: 'key1' });
-                expect(container.children).to.have.length(1);
-                expect(container.firstChild).to.equal(el);
+                expect(container.children).toHaveLength(1);
+                expect(container.firstChild).toEqual(el);
             });
 
             it('should replace the DOM node when a key is removed', () => {
                 div.setAttribute('key', 'key0');
                 patchOuter(div, render, { tag: 'span' });
-                expect(container.children).to.have.length(1);
-                expect(container.firstChild.tagName).to.equal('SPAN');
-                expect(container.firstChild).to.equal(el);
+                expect(container.children).toHaveLength(1);
+                expect(container.firstChild.tagName).toEqual('SPAN');
+                expect(container.firstChild).toEqual(el);
             });
 
             it('should replace the DOM node when a key is added', () => {
                 patchOuter(div, render, { tag: 'span', key: 'key2' });
-                expect(container.children).to.have.length(1);
-                expect(container.firstChild).to.equal(el);
+                expect(container.children).toHaveLength(1);
+                expect(container.firstChild).toEqual(el);
             });
         });
     });
@@ -209,8 +208,8 @@ describe('patching an element', () => {
         const divTwo = container.appendChild(document.createElement('div'));
         patchOuter(divTwo, render);
 
-        expect(container.children).to.have.length(1);
-        expect(container.firstChild).to.not.equal(el);
+        expect(container.children).toHaveLength(1);
+        expect(container.firstChild).not.toBe(el);
     });
 
     it('should throw an error when patching too many elements', () => {
@@ -219,20 +218,19 @@ describe('patching an element', () => {
             elementVoid('div');
             elementVoid('div');
         }
-
-        expect(() => patchOuter(div, render)).to.throw(
-            'There must be ' +
-                'exactly one top level call corresponding to the patched element.',
-        );
+        const error =
+            'There must be exactly one top level call corresponding to the patched element.';
+        expect(() => patchOuter(div, render)).toThrowError(new Error(error));
     });
 
     describe('that does not exist', function() {
         it('should throw an error', function() {
+            const error = 'Patch invoked without an element.';
             expect(() =>
                 patchOuter(null, function() {
-                    expect(false).to.be.true;
-                }),
-            ).to.throw('Patch invoked without an element');
+                    expect(false).toBeTruthy();
+                })
+            ).toThrow(new Error(error));
         });
     });
 });

--- a/packages/melody-idom/__tests__/RawSpec.ts
+++ b/packages/melody-idom/__tests__/RawSpec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { patch, raw, text, rawString, elementOpen, elementClose } from '../src';
-import { expect } from 'chai';
 
 describe('raw text nodes', () => {
     let container;
@@ -35,7 +34,7 @@ describe('raw text nodes', () => {
             });
             const node = container.childNodes[0];
 
-            expect(node.outerHTML).to.equal('<span>hello</span>');
+            expect(node.outerHTML).toEqual('<span>hello</span>');
         });
     });
 
@@ -46,7 +45,7 @@ describe('raw text nodes', () => {
             });
             const node = container.childNodes[0];
 
-            expect(node.outerHTML).to.equal('<span>hello</span>');
+            expect(node.outerHTML).toEqual('<span>hello</span>');
         });
     });
 
@@ -60,7 +59,7 @@ describe('raw text nodes', () => {
             patch(container, () => render('<span>Hello World!</span>'));
             const node = container.childNodes[0];
 
-            expect(node.outerHTML).to.equal('<span>Hello World!</span>');
+            expect(node.outerHTML).toEqual('<span>Hello World!</span>');
         });
 
         it('should skip the DOM when the text is unchanged', () => {
@@ -68,8 +67,8 @@ describe('raw text nodes', () => {
             const oldNode = container.childNodes[0];
             patch(container, () => render('<span>Hello</span>'));
             const node = container.childNodes[0];
-            expect(node).to.equal(oldNode);
-            expect(node.outerHTML).to.equal('<span>Hello</span>');
+            expect(node).toEqual(oldNode);
+            expect(node.outerHTML).toEqual('<span>Hello</span>');
         });
     });
 
@@ -80,35 +79,35 @@ describe('raw text nodes', () => {
 
         it('should remove unnecessary elements', () => {
             patch(container, () =>
-                render('<span>Hello</span><div>World</div>'),
+                render('<span>Hello</span><div>World</div>')
             );
-            expect(container.outerHTML).to.equal(
-                '<div><span>Hello</span><div>World</div></div>',
+            expect(container.outerHTML).toEqual(
+                '<div><span>Hello</span><div>World</div></div>'
             );
 
             patch(container, () => render('<span>Hello World!</span>'));
-            expect(container.outerHTML).to.equal(
-                '<div><span>Hello World!</span></div>',
+            expect(container.outerHTML).toEqual(
+                '<div><span>Hello World!</span></div>'
             );
         });
 
         it('should not replace elements if data is unchanged', () => {
             patch(container, () =>
-                render('<span>Hello</span><div>World</div>'),
+                render('<span>Hello</span><div>World</div>')
             );
             const firstChild = container.children[0];
             const secondChild = container.children[1];
-            expect(container.outerHTML).to.equal(
-                '<div><span>Hello</span><div>World</div></div>',
+            expect(container.outerHTML).toEqual(
+                '<div><span>Hello</span><div>World</div></div>'
             );
 
             patch(container, () =>
-                render('<span>Hello</span><div>World</div>'),
+                render('<span>Hello</span><div>World</div>')
             );
-            expect(firstChild).to.equal(container.children[0]);
-            expect(secondChild).to.equal(container.children[1]);
-            expect(container.outerHTML).to.equal(
-                '<div><span>Hello</span><div>World</div></div>',
+            expect(firstChild).toEqual(container.children[0]);
+            expect(secondChild).toEqual(container.children[1]);
+            expect(container.outerHTML).toEqual(
+                '<div><span>Hello</span><div>World</div></div>'
             );
         });
     });
@@ -120,27 +119,23 @@ describe('raw text nodes', () => {
 
         it('should not render anything', function() {
             patch(container, () => render(''));
-            expect(container.outerHTML).to.equal('<div></div>');
+            expect(container.outerHTML).toEqual('<div></div>');
         });
 
         it('should override the previous raw text', function() {
             patch(container, () => render('<span>Test</span>'));
-            expect(container.outerHTML).to.equal(
-                '<div><span>Test</span></div>',
-            );
+            expect(container.outerHTML).toEqual('<div><span>Test</span></div>');
 
             patch(container, () => render(''));
-            expect(container.outerHTML).to.equal('<div></div>');
+            expect(container.outerHTML).toEqual('<div></div>');
         });
 
         it('should override the previously empty raw text', function() {
             patch(container, () => render(''));
-            expect(container.outerHTML).to.equal('<div></div>');
+            expect(container.outerHTML).toEqual('<div></div>');
 
             patch(container, () => render('<span>Test</span>'));
-            expect(container.outerHTML).to.equal(
-                '<div><span>Test</span></div>',
-            );
+            expect(container.outerHTML).toEqual('<div><span>Test</span></div>');
         });
     });
 });

--- a/packages/melody-idom/__tests__/SkipNodeSpec.ts
+++ b/packages/melody-idom/__tests__/SkipNodeSpec.ts
@@ -16,7 +16,6 @@
  */
 
 import { patch, elementVoid, skipNode } from '../src';
-import { expect } from 'chai';
 
 describe('skip', () => {
     let container;
@@ -43,8 +42,8 @@ describe('skip', () => {
             elementVoid('span');
         });
 
-        expect(container.firstChild).to.equal(firstChild);
-        expect(container.lastChild).to.equal(lastChild);
+        expect(container.firstChild).toEqual(firstChild);
+        expect(container.lastChild).toEqual(lastChild);
     });
 
     it('should keep nodes that were skipped', () => {
@@ -53,6 +52,6 @@ describe('skip', () => {
             skipNode();
         });
 
-        expect(container.lastChild).to.equal(lastChild);
+        expect(container.lastChild).toEqual(lastChild);
     });
 });

--- a/packages/melody-idom/__tests__/SkipSpec.ts
+++ b/packages/melody-idom/__tests__/SkipSpec.ts
@@ -23,7 +23,6 @@ import {
     skip,
     text,
 } from '../src';
-import { expect } from 'chai';
 
 describe('skip', () => {
     let container;
@@ -52,51 +51,51 @@ describe('skip', () => {
         patch(container, render, { skip: false });
         patch(container, render, { skip: true });
 
-        expect(container.textContent).to.equal('some text');
+        expect(container.textContent).toEqual('some text');
     });
 
     it('should throw if an element is declared after skipping', () => {
+        const error =
+            'elementOpen() may not be called inside an element that has called skip().';
         expect(() => {
             patch(container, () => {
                 skip();
                 elementOpen('div');
                 elementClose('div');
             });
-        }).to.throw(
-            'elementOpen() may not be called inside an element that has called skip().',
-        );
+        }).toThrowError(new Error(error));
     });
 
     it('should throw if a text is declared after skipping', () => {
+        const error =
+            'text() may not be called inside an element that has called skip().';
         expect(() => {
             patch(container, () => {
                 skip();
                 text('text');
             });
-        }).to.throw(
-            'text() may not be called inside an element that has called skip().',
-        );
+        }).toThrowError(new Error(error));
     });
 
     it('should throw skip is called after declaring an element', () => {
+        const error =
+            'skip() must come before any child declarations inside the current element.';
         expect(() => {
             patch(container, () => {
                 elementVoid('div');
                 skip();
             });
-        }).to.throw(
-            'skip() must come before any child declarations inside the current element.',
-        );
+        }).toThrowError(new Error(error));
     });
 
     it('should throw skip is called after declaring a text', () => {
+        const error =
+            'skip() must come before any child declarations inside the current element.';
         expect(() => {
             patch(container, () => {
                 text('text');
                 skip();
             });
-        }).to.throw(
-            'skip() must come before any child declarations inside the current element.',
-        );
+        }).toThrowError(new Error(error));
     });
 });

--- a/packages/melody-idom/__tests__/StylesSpec.ts
+++ b/packages/melody-idom/__tests__/StylesSpec.ts
@@ -16,7 +16,6 @@
  */
 
 import { patch, attributes, elementVoid } from '../src';
-import { expect } from 'chai';
 
 describe('style updates', () => {
     let container;
@@ -45,12 +44,12 @@ describe('style updates', () => {
             render({
                 color: 'white',
                 backgroundColor: 'red',
-            }),
+            })
         );
         const el = container.childNodes[0];
 
-        expect(el.style.color).to.equal('white');
-        expect(el.style.backgroundColor).to.equal('red');
+        expect(el.style.color).toEqual('white');
+        expect(el.style.backgroundColor).toEqual('red');
     });
 
     if (browserSupportsCssCustomProperties()) {
@@ -58,69 +57,69 @@ describe('style updates', () => {
             patch(container, () =>
                 render({
                     '--some-var': 'blue',
-                }),
+                })
             );
             const el = container.childNodes[0];
 
-            expect(el.style.getPropertyValue('--some-var')).to.equal('blue');
+            expect(el.style.getPropertyValue('--some-var')).toEqual('blue');
         });
     }
 
     it('should support setProperty', function() {
         const el = document.createElement('div');
         el.style.setProperty('background-color', 'red');
-        expect(el.style.backgroundColor).to.equal('red');
+        expect(el.style.backgroundColor).toEqual('red');
     });
 
     it('should handle dashes in property names', () => {
         patch(container, () =>
             render({
                 'background-color': 'red',
-            }),
+            })
         );
         const el = container.childNodes[0];
 
-        expect(el.style.backgroundColor).to.equal('red');
+        expect(el.style.backgroundColor).toEqual('red');
     });
 
     it('should update the correct style properties', () => {
         patch(container, () =>
             render({
                 color: 'white',
-            }),
+            })
         );
         patch(container, () =>
             render({
                 color: 'red',
-            }),
+            })
         );
         const el = container.childNodes[0];
 
-        expect(el.style.color).to.equal('red');
+        expect(el.style.color).toEqual('red');
     });
 
     it('should remove properties not present in the new object', () => {
         patch(container, () =>
             render({
                 color: 'white',
-            }),
+            })
         );
         patch(container, () =>
             render({
                 backgroundColor: 'red',
-            }),
+            })
         );
         const el = container.childNodes[0];
 
-        expect(el.style.color).to.equal('');
-        expect(el.style.backgroundColor).to.equal('red');
+        expect(el.style.color).toEqual('');
+        expect(el.style.backgroundColor).toEqual('red');
     });
 
     it('should render with the correct style properties for strings', () => {
         patch(container, () => render('color: white; background-color: red;'));
         const el = container.childNodes[0];
 
-        expect(el.style.color).to.equal('white');
-        expect(el.style.backgroundColor).to.equal('red');
+        expect(el.style.color).toEqual('white');
+        expect(el.style.backgroundColor).toEqual('red');
     });
 });

--- a/packages/melody-idom/__tests__/TextNodesSpec.ts
+++ b/packages/melody-idom/__tests__/TextNodesSpec.ts
@@ -16,7 +16,6 @@
  */
 
 import { patch, text, elementOpenStart } from '../src';
-import { expect } from 'chai';
 
 describe('text nodes', () => {
     let container;
@@ -37,8 +36,8 @@ describe('text nodes', () => {
             });
             const node = container.childNodes[0];
 
-            expect(node.textContent).to.equal('Hello world!');
-            expect(node).to.be.instanceof(Text);
+            expect(node.textContent).toEqual('Hello world!');
+            expect(node).toBeInstanceOf(Text);
         });
 
         it('should allow for multiple text nodes under one parent element', () => {
@@ -48,18 +47,18 @@ describe('text nodes', () => {
                 text('!');
             });
 
-            expect(container.textContent).to.equal('Hello World!');
+            expect(container.textContent).toEqual('Hello World!');
         });
 
         it('should throw when inside virtual attributes element', () => {
+            const error =
+                'text() can not be called between elementOpenStart() and elementOpenEnd().';
             expect(() => {
                 patch(container, () => {
                     elementOpenStart('div');
                     text('Hello');
                 });
-            }).to.throw(
-                'text() can not be called between elementOpenStart() and elementOpenEnd().',
-            );
+            }).toThrowError(new Error(error));
         });
     });
 
@@ -73,7 +72,7 @@ describe('text nodes', () => {
             patch(container, () => render('Hello World!'));
             const node = container.childNodes[0];
 
-            expect(node.textContent).to.equal('Hello World!');
+            expect(node.textContent).toEqual('Hello World!');
         });
     });
 });

--- a/packages/melody-idom/__tests__/VirtualAttributesSpec.ts
+++ b/packages/melody-idom/__tests__/VirtualAttributesSpec.ts
@@ -23,7 +23,6 @@ import {
     elementClose,
     attr,
 } from '../src';
-import { expect } from 'chai';
 
 describe('virtual attribute updates', () => {
     let container;
@@ -51,111 +50,111 @@ describe('virtual attribute updates', () => {
             patch(container, () =>
                 render({
                     key: 'hello',
-                }),
+                })
             );
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-expanded')).to.equal('hello');
+            expect(el.getAttribute('data-expanded')).toEqual('hello');
         });
 
         it('should be not present when not specified', () => {
             patch(container, () =>
                 render({
                     key: false,
-                }),
+                })
             );
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-expanded')).to.equal(null);
+            expect(el.getAttribute('data-expanded')).toBeNull();
         });
 
         it('should update the DOM when they change', () => {
             patch(container, () =>
                 render({
                     key: 'foo',
-                }),
+                })
             );
             patch(container, () =>
                 render({
                     key: 'bar',
-                }),
+                })
             );
             const el = container.childNodes[0];
 
-            expect(el.getAttribute('data-expanded')).to.equal('bar');
+            expect(el.getAttribute('data-expanded')).toEqual('bar');
         });
 
         it('should include static attributes', function() {
             patch(container, () =>
                 render({
                     key: false,
-                }),
+                })
             );
             const el = container.childNodes[0];
-            expect(el.getAttribute('data-static')).to.equal('world');
+            expect(el.getAttribute('data-static')).toEqual('world');
         });
 
         it('should throw when defined outside virtual attributes element', () => {
+            const error =
+                'attr() can only be called after calling elementOpenStart().';
             expect(() => {
                 patch(container, () => {
                     attr('data-expanded', true);
                 });
-            }).to.throw(
-                'attr() can only be called after calling elementOpenStart().',
-            );
+            }).toThrowError(new Error(error));
         });
     });
 
     it('should throw when a virtual attributes element is unclosed', () => {
+        const error =
+            'elementOpenEnd() must be called after calling elementOpenStart().';
         expect(() => {
             patch(container, () => {
                 elementOpenStart('div');
             });
-        }).to.throw(
-            'elementOpenEnd() must be called after calling elementOpenStart().',
-        );
+        }).toThrowError(new Error(error));
     });
 
     it('should throw when virtual attributes element is closed without being opened', () => {
+        const error =
+            'elementOpenEnd() can only be called after calling elementOpenStart().';
         expect(() => {
             patch(container, () => {
                 elementOpenEnd('div');
             });
-        }).to.throw(
-            'elementOpenEnd() can only be called after calling elementOpenStart().',
-        );
+        }).toThrowError(new Error(error));
     });
 
     it('should throw when opening an element inside a virtual attributes element', () => {
+        const error =
+            'elementOpen() can not be called between elementOpenStart() and elementOpenEnd().';
         expect(() => {
             patch(container, () => {
                 elementOpenStart('div');
                 elementOpen('div');
             });
-        }).to.throw(
-            'elementOpen() can not be called between elementOpenStart() and elementOpenEnd().',
-        );
+        }).toThrowError(new Error(error));
     });
 
     it('should throw when opening a virtual attributes element inside a virtual attributes element', () => {
+        const error =
+            'elementOpenStart() can not be called between elementOpenStart() and elementOpenEnd().';
         expect(() => {
             patch(container, () => {
                 elementOpenStart('div');
                 elementOpenStart('div');
             });
-        }).to.throw(
-            'elementOpenStart() can not be called between elementOpenStart() and elementOpenEnd().',
-        );
+        }).toThrowError(new Error(error));
     });
 
     it('should throw when closing an element inside a virtual attributes element', () => {
+        const error =
+            'elementClose() can not be called between elementOpenStart() and elementOpenEnd().';
         expect(() => {
             patch(container, () => {
                 elementOpenStart('div');
                 elementClose('div');
             });
-        }).to.throw(
-            'elementClose() can not be called between elementOpenStart() and elementOpenEnd().',
-        );
+        }).toThrowError(new Error(error));
     });
 });

--- a/packages/melody-idom/src/virtual_elements.ts
+++ b/packages/melody-idom/src/virtual_elements.ts
@@ -69,11 +69,11 @@ var elementOpen = function(tag, key, statics, var_args) {
     var data = getData(node);
 
     /*
-   * Checks to see if one or more attributes have changed for a given Element.
-   * When no attributes have changed, this is much faster than checking each
-   * individual argument. When attributes have changed, the overhead of this is
-   * minimal.
-   */
+     * Checks to see if one or more attributes have changed for a given Element.
+     * When no attributes have changed, this is much faster than checking each
+     * individual argument. When attributes have changed, the overhead of this is
+     * minimal.
+     */
     const attrsArr = data.attrsArr;
     const newAttrs = data.newAttrs;
     const isNew = !attrsArr.length;
@@ -325,9 +325,9 @@ var text = function(value, var_args) {
         var formatted = value;
         for (var i = 1; i < arguments.length; i += 1) {
             /*
-       * Call the formatter function directly to prevent leaking arguments.
-       * https://github.com/google/incremental-dom/pull/204#issuecomment-178223574
-       */
+             * Call the formatter function directly to prevent leaking arguments.
+             * https://github.com/google/incremental-dom/pull/204#issuecomment-178223574
+             */
             var fn = arguments[i];
             formatted = fn(formatted);
         }

--- a/packages/melody-plugin-idom/src/visitors/mount.js
+++ b/packages/melody-plugin-idom/src/visitors/mount.js
@@ -152,7 +152,7 @@ Example:
 This is the placeholder content that will be shown to your users while the async component is being loaded.`,
                             path.node.loc.start.line === path.node.loc.end.line
                                 ? path.node.loc.end.column -
-                                  path.node.loc.start.column
+                                      path.node.loc.start.column
                                 : 'mount async'.length
                         );
                     }

--- a/packages/melody-redux/__tests__/ConnectSpec.js
+++ b/packages/melody-redux/__tests__/ConnectSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { createComponent, RECEIVE_PROPS, render } from 'melody-component';
 import {
     component,
@@ -73,11 +71,11 @@ describe('Connect', function() {
             const ConnectedComponent = enhance(Component);
 
             const dom = renderWithProvide(ConnectedComponent);
-            assert.equal(dom.outerHTML, '<div><div>foo!</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>foo!</div></div>');
             store.dispatch({ type: 'SET', payload: 'bar' });
 
             finishRendering();
-            assert.equal(dom.outerHTML, '<div><div>bar!</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>bar!</div></div>');
             done();
         });
 
@@ -88,11 +86,11 @@ describe('Connect', function() {
 
             const dom = renderWithProvide(ConnectedComponent);
 
-            assert.equal(dom.outerHTML, '<div><div>foo!</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>foo!</div></div>');
             store.dispatch({ type: 'SET', payload: 'bar' });
 
             finishRendering();
-            assert.equal(dom.outerHTML, '<div><div>bar!</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>bar!</div></div>');
             done();
         });
 
@@ -105,11 +103,11 @@ describe('Connect', function() {
 
             const dom = renderWithProvide(ConnectedComponent);
 
-            assert.equal(dom.outerHTML, '<div><div>foo?!</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>foo?!</div></div>');
             store.dispatch({ type: 'SET', payload: 'bar' });
 
             finishRendering();
-            assert.equal(dom.outerHTML, '<div><div>bar?!</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>bar?!</div></div>');
             done();
         });
 
@@ -145,7 +143,7 @@ describe('Connect', function() {
             const ConnectedComponent = enhance(Component);
 
             const dom = renderWithProvide(ConnectedComponent, { value: 'bar' });
-            assert.equal(dom.outerHTML, '<div><div>bar</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>bar</div></div>');
         });
 
         it('should have higher priority for stateToProps than component props', () => {
@@ -153,7 +151,7 @@ describe('Connect', function() {
             const ConnectedComponent = enhance(Component);
 
             const dom = renderWithProvide(ConnectedComponent, { value: 'bar' });
-            assert.equal(dom.outerHTML, '<div><div>foo!</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>foo!</div></div>');
         });
 
         it('should map dispatchable action to props', done => {
@@ -165,7 +163,7 @@ describe('Connect', function() {
                     setValue: val => {
                         return { type: 'SET', payload: val };
                     },
-                },
+                }
             );
             let dom;
             const Component = createComponent(
@@ -178,14 +176,13 @@ describe('Connect', function() {
                         setTimeout(() => {
                             this.getState().setValue('bar');
                             finishRendering();
-                            assert.equal(
-                                dom.outerHTML,
-                                '<div><div>bar</div></div>',
+                            expect(dom.outerHTML).toEqual(
+                                '<div><div>bar</div></div>'
                             );
                             done();
                         }, 1);
                     },
-                }),
+                })
             );
             const ConnectedComponent = enhance(Component);
             dom = renderWithProvide(ConnectedComponent);
@@ -205,7 +202,7 @@ describe('Connect', function() {
                             });
                         },
                     };
-                },
+                }
             );
             let dom;
             const Component = createComponent(
@@ -218,14 +215,13 @@ describe('Connect', function() {
                         setTimeout(() => {
                             this.getState().setValue('bar');
                             finishRendering();
-                            assert.equal(
-                                dom.outerHTML,
-                                '<div><div>bar_melody</div></div>',
+                            expect(dom.outerHTML).toEqual(
+                                '<div><div>bar_melody</div></div>'
                             );
                             done();
                         }, 1);
                     },
-                }),
+                })
             );
             const ConnectedComponent = enhance(Component);
             dom = renderWithProvide(ConnectedComponent, { suffix: 'melody' });
@@ -240,7 +236,7 @@ describe('Connect', function() {
                     setValue: val => {
                         return { type: 'SET', payload: val };
                     },
-                },
+                }
             );
             const Component = createComponent(
                 template,
@@ -248,13 +244,13 @@ describe('Connect', function() {
                 ({ componentDidMount }) => ({
                     componentDidMount() {
                         componentDidMount.call(this);
-                        assert.equal(this.el.outerHTML, '<div>foo</div>');
+                        expect(this.el.outerHTML).toEqual('<div>foo</div>');
                         this.getState().setValue('bar');
                         finishRendering();
-                        assert.equal(this.el.outerHTML, '<div>bar</div>');
+                        expect(this.el.outerHTML).toEqual('<div>bar</div>');
                         done();
                     },
-                }),
+                })
             );
             const ConnectedComponent = enhance(Component);
             renderWithProvide(ConnectedComponent);
@@ -300,7 +296,7 @@ describe('Connect', function() {
             Component = createComponent(
                 template,
                 internalReducer,
-                instanceMixin,
+                instanceMixin
             );
         });
 
@@ -309,10 +305,10 @@ describe('Connect', function() {
             const ConnectedComponent = enhance(Component);
 
             const dom = renderWithProvide(ConnectedComponent);
-            assert.equal(dom.outerHTML, '<div><div>foo! foo</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>foo! foo</div></div>');
             instance.dispatch({ type: 'SET_INTERNAL', payload: 'bar' });
             finishRendering();
-            assert.equal(dom.outerHTML, '<div><div>foo! bar</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>foo! bar</div></div>');
             done();
         });
 
@@ -325,7 +321,7 @@ describe('Connect', function() {
             store.dispatch({ type: 'SET', payload: 'qux' });
             finishRendering();
 
-            assert.equal(dom.outerHTML, '<div><div>qux! bar</div></div>');
+            expect(dom.outerHTML).toEqual('<div><div>qux! bar</div></div>');
             done();
         });
 
@@ -338,7 +334,7 @@ describe('Connect', function() {
                         text(_context.value);
                         elementClose('div');
                     },
-                }),
+                })
             );
 
             const template = {
@@ -370,12 +366,11 @@ describe('Connect', function() {
 
             const Component = createComponent(template, reducer, instanceMixin);
             const dom = renderWithProvide(Component);
-            assert.equal(dom.outerHTML, '<div><div></div></div>');
+            expect(dom.outerHTML).toEqual('<div><div></div></div>');
             instance.dispatch({ type: 'SHOW' });
             finishRendering();
-            assert.equal(
-                dom.outerHTML,
-                '<div><div><div>foo!</div></div></div>',
+            expect(dom.outerHTML).toEqual(
+                '<div><div><div>foo!</div></div></div>'
             );
             done();
         });
@@ -423,7 +418,7 @@ describe('Connect', function() {
                             componentDidUpdate.call(this, ...args);
                         },
                     };
-                },
+                }
             );
             const enhance = connect(createMapStateToProps);
             const Container = enhance(ContainerDumb);
@@ -441,9 +436,9 @@ describe('Connect', function() {
             finishRendering();
             store.dispatch({ type: 'SET', payload: 'foo' });
             finishRendering();
-            assert.equal(updatedCount, 0);
-            assert.equal(memoizedReturnCount, 2);
-            assert.equal(factoryCallCount, 2);
+            expect(updatedCount).toEqual(0);
+            expect(memoizedReturnCount).toEqual(2);
+            expect(factoryCallCount).toEqual(2);
         });
 
         it('should allow providing a factory function to mapDispatchToProps', () => {
@@ -473,7 +468,7 @@ describe('Connect', function() {
             function mergeParentDispatch(
                 stateProps,
                 dispatchProps,
-                parentProps,
+                parentProps
             ) {
                 return {
                     ...stateProps,
@@ -498,12 +493,12 @@ describe('Connect', function() {
                         updatedCount++;
                         componentDidUpdate.call(this, ...args);
                     },
-                }),
+                })
             );
             const enhance = connect(
                 mapStateToProps,
                 createMapDispatchToProps,
-                mergeParentDispatch,
+                mergeParentDispatch
             );
             const Container = enhance(ContainerDumb);
 
@@ -531,15 +526,15 @@ describe('Connect', function() {
                         componentDidMount.call(this);
                         this.dispatch({ type: 'TOGGLE' });
                     },
-                }),
+                })
             );
             renderWithProvide(App);
             finishRendering();
             store.dispatch({ type: 'SET', payload: 'bar' });
             finishRendering();
-            assert.equal(updatedCount, 2);
-            assert.equal(memoizedReturnCount, 2);
-            assert.equal(factoryCallCount, 2);
+            expect(updatedCount).toEqual(2);
+            expect(memoizedReturnCount).toEqual(2);
+            expect(factoryCallCount).toEqual(2);
         });
     });
 
@@ -565,7 +560,7 @@ describe('Connect', function() {
 
         const dom = renderWithProvide(Component);
 
-        assert.equal(dom.outerHTML, '<div><div><div>foo</div></div></div>');
+        expect(dom.outerHTML).toEqual('<div><div><div>foo</div></div></div>');
         done();
     });
 });

--- a/packages/melody-redux/__tests__/ShouldComponentUpdateConnectSpec.js
+++ b/packages/melody-redux/__tests__/ShouldComponentUpdateConnectSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
 import { createStore } from 'redux';
 import { createComponent, render } from 'melody-component';
 import { component, elementOpen, elementClose, text, flush } from 'melody-idom';
@@ -76,10 +75,10 @@ it('should work when connected component is not rendered through typical render 
     const root = document.createElement('ol');
 
     render(root, ProvidedApp);
-    assert.equal(root.outerHTML, '<ol><li><span>child</span></li></ol>');
+    expect(root.outerHTML).toEqual('<ol><li><span>child</span></li></ol>');
     store.dispatch({ type: 'REFRESH' });
     // setTimeout(() => {
-    assert.equal(root.outerHTML, '<ol><li><span>child</span></li></ol>');
+    expect(root.outerHTML).toEqual('<ol><li><span>child</span></li></ol>');
     done();
     // }, 500);
 });
@@ -128,7 +127,7 @@ it('should not delete child component if child did not need rendering', done => 
     const root = document.createElement('li');
 
     render(root, ProvidedApp, { children: store.getState() });
-    assert.equal(root.outerHTML, '<li><span>1</span></li>');
+    expect(root.outerHTML).toEqual('<li><span>1</span></li>');
 
     // trigger dispatch on ConnectedChild
     // ParentComponent does not receive a dispatch
@@ -144,6 +143,6 @@ it('should not delete child component if child did not need rendering', done => 
             return 10;
         },
     });
-    assert.equal(root.outerHTML, '<li><span>1</span></li>');
+    expect(root.outerHTML).toEqual('<li><span>1</span></li>');
     done();
 });

--- a/packages/melody-runtime/__tests__/AsyncComponentSpec.js
+++ b/packages/melody-runtime/__tests__/AsyncComponentSpec.js
@@ -112,7 +112,7 @@ describe('AsyncComponent', () => {
             '<div>Foo</div><strong>Network connection issue</strong>'
         );
 
-        expect(unmounted).toEqual(false);
+        expect(unmounted).toBeFalsy();
     });
 
     it('should render a promised component conditionally', async function() {
@@ -172,7 +172,7 @@ describe('AsyncComponent', () => {
         run();
         expect(el.innerHTML).toEqual('<div><div>Foo</div></div>');
 
-        expect(unmounted).toEqual(false);
+        expect(unmounted).toBeFalsy();
     });
 
     it('should render the correct async component when changed during loading', async function() {
@@ -233,7 +233,7 @@ describe('AsyncComponent', () => {
             '<div><span>No magic component</span></div>'
         );
 
-        expect(unmounted).toEqual(false);
+        expect(unmounted).toBeFalsy();
     });
 
     it('should unmount the async component', async function() {
@@ -295,7 +295,7 @@ describe('AsyncComponent', () => {
             '<div><span>No magic component</span></div>'
         );
 
-        expect(unmounted).toEqual(true);
+        expect(unmounted).toBeTruthy();
     });
 
     it('should change components during loading', async function() {
@@ -358,7 +358,7 @@ describe('AsyncComponent', () => {
         run(2);
         expect(el.innerHTML).toEqual('<div><div>Foo</div></div>');
 
-        expect(unmounted).toEqual(false);
+        expect(unmounted).toBeFalsy();
     });
 
     it('should switch components after loading', async function() {
@@ -424,7 +424,7 @@ describe('AsyncComponent', () => {
         run(2);
         expect(el.innerHTML).toEqual('<div><div>Foo</div></div>');
 
-        expect(unmounted).toEqual(true);
+        expect(unmounted).toBeTruthy();
     });
 
     it('should ignore unnecessary async component', async function() {
@@ -490,8 +490,8 @@ describe('AsyncComponent', () => {
             '<div><span>No magic component</span></div>'
         );
 
-        expect(notified).toEqual(false);
-        expect(unmounted).toEqual(false);
+        expect(notified).toBeFalsy();
+        expect(unmounted).toBeFalsy();
     });
 });
 

--- a/packages/melody-runtime/__tests__/ContextSpec.js
+++ b/packages/melody-runtime/__tests__/ContextSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 
 import { createSubContext } from '../src';
 
@@ -32,18 +31,18 @@ describe('createSubContext', function() {
 
     it('returns a new sub context', function() {
         const subContext = createSubContext(context);
-        expect(subContext === context).to.be.false;
+        expect(subContext === context).toBeFalsy();
     });
 
     it('provides access to the parent context properties', function() {
         const subContext = createSubContext(context);
-        expect(subContext.b).to.equal(42);
+        expect(subContext.b).toEqual(42);
     });
 
     it('enhances the child context with new properties', function() {
         const subContext = createSubContext(context, { c: 1 });
-        expect(subContext.b).to.equal(42);
-        expect(subContext.c).to.equal(1);
-        expect(context.c).to.be.undefined;
+        expect(subContext.b).toEqual(42);
+        expect(subContext.c).toEqual(1);
+        expect(context.c).toBeUndefined();
     });
 });

--- a/packages/melody-runtime/__tests__/FilterSpec.js
+++ b/packages/melody-runtime/__tests__/FilterSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 
 import {
     batch,
@@ -43,7 +42,7 @@ describe('Twig filter runtime', function() {
                 ['g', 'h', 'i'],
             ];
             const actual = batch(items, 3, 'No Item');
-            expect(actual).to.deep.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should insert missing if needed', function() {
@@ -54,7 +53,7 @@ describe('Twig filter runtime', function() {
                 ['g', 'No Item', 'No Item'],
             ];
             const actual = batch(items, 3, 'No Item');
-            expect(actual).to.deep.eql(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -63,7 +62,7 @@ describe('Twig filter runtime', function() {
             const input = { a: 'b', c: false };
             const expected = ['a', 'b', 'c', undefined];
             const actual = attrs(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should keep falsy values that are not false', function() {
@@ -79,7 +78,7 @@ describe('Twig filter runtime', function() {
                 undefined,
             ];
             const actual = attrs(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should ignore inherited properties', function() {
@@ -87,7 +86,7 @@ describe('Twig filter runtime', function() {
             input.b = 1;
             const expected = ['b', 1];
             const actual = attrs(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -96,7 +95,7 @@ describe('Twig filter runtime', function() {
             const input = { declaration: 'value' };
             const expected = 'declaration:value;';
             const actual = styles(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should obey conditions for adding other styles', function() {
@@ -114,7 +113,7 @@ describe('Twig filter runtime', function() {
             };
             const expected = 'color:red;background-color:blue;left:0;';
             const actual = styles(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -123,42 +122,42 @@ describe('Twig filter runtime', function() {
             const input = { class1: true };
             const expected = 'class1';
             const actual = classes(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should add base class', function() {
             const input = { base: 'base-class' };
             const expected = 'base-class';
             const actual = classes(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should add multiple base classes', function() {
             const input = { base: 'base-class base-class1 base-class2' };
             const expected = 'base-class base-class1 base-class2';
             const actual = classes(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should add base class and conditional class', function() {
             const input = { base: 'base-class', class1: true };
             const expected = 'base-class class1';
             const actual = classes(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should add base class and obey conditions for adding other classes', function() {
             const input = { base: 'base-class', class1: true, class2: false };
             const expected = 'base-class class1';
             const actual = classes(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should obey conditions for adding other classes', function() {
             const input = { class1: true, class2: false };
             const expected = 'class1';
             const actual = classes(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should add multiple base classes and obey conditions for adding other classes', function() {
@@ -169,7 +168,7 @@ describe('Twig filter runtime', function() {
             };
             const expected = 'base-class base-class1 class1';
             const actual = classes(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -179,16 +178,16 @@ describe('Twig filter runtime', function() {
             const inputB = { b: 2 };
             const expected = { a: 1, b: 2 };
             const actual = merge(inputA, inputB);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should not mutate its arguments', function() {
             const inputA = { a: 1 };
             const inputB = { b: 2 };
             merge(inputA, inputB);
-            expect(inputA).to.eql({ a: 1 });
-            expect(inputA.b).to.be.undefined;
-            expect(inputB).to.eql({ b: 2 });
+            expect(inputA).toEqual({ a: 1 });
+            expect(inputA.b).toBeUndefined();
+            expect(inputB).toEqual({ b: 2 });
         });
 
         it('should merge arrays', function() {
@@ -196,7 +195,7 @@ describe('Twig filter runtime', function() {
             const inputB = [3, 4];
             const expected = [1, 2, 3, 4];
             const actual = merge(inputA, inputB);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -207,7 +206,7 @@ describe('Twig filter runtime', function() {
             const actual = replace(input, {
                 world: 'universe',
             });
-            expect(actual).to.equal(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -216,20 +215,20 @@ describe('Twig filter runtime', function() {
             const input = [1, 2, 3, 4];
             const expected = [4, 3, 2, 1];
             const actual = reverse(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should reverse a string', function() {
             const input = '1234';
             const expected = '4321';
             const actual = reverse(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should not reverse an object', function() {
             const input = { a: 1, b: 2 };
             const actual = reverse(input);
-            expect(actual).to.equal(input);
+            expect(actual).toEqual(input);
         });
     });
 
@@ -238,28 +237,28 @@ describe('Twig filter runtime', function() {
             const input = 0.8241331;
             const expected = 0.9;
             const actual = round(input, 1, 'ceil');
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should floor the number to the given precision', function() {
             const input = 0.8241331;
             const expected = 0.8;
             const actual = round(input, 1, 'floor');
-            expect(actual).to.equal(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should round the number', function() {
             const input = 0.8241331;
             const expected = 1;
             const actual = round(input, 0, 'common');
-            expect(actual).to.equal(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should use 0 precision as default', function() {
             const input = 0.8241331;
             const expected = 1;
             const actual = round(input);
-            expect(actual).to.equal(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -268,7 +267,7 @@ describe('Twig filter runtime', function() {
             const input = 'hello world is fun!';
             const expected = 'Hello World Is Fun!';
             const actual = title(input);
-            expect(actual).to.equal(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -277,14 +276,14 @@ describe('Twig filter runtime', function() {
             const input = 'foo=hello world';
             const expected = 'foo%3Dhello%20world';
             const actual = url_encode(input);
-            expect(actual).to.equal(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should encode an object', function() {
             const input = { foo: 'hello world', 'foo bar': 2 };
             const expected = 'foo=hello%20world&foo%20bar=2';
             const actual = url_encode(input);
-            expect(actual).to.equal(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
@@ -293,108 +292,106 @@ describe('Twig filter runtime', function() {
             const input = '<div class="foo">test</div>';
             const expected = 'test';
             const actual = striptags(input);
-            expect(actual).to.equal(expected);
+            expect(actual).toEqual(expected);
         });
     });
 
     describe('number_format filter', function() {
         it('should format a number', function() {
-            expect(number_format(455121.213, 2, ',', '.')).to.equal(
+            expect(number_format(455121.213, 2, ',', '.')).toEqual(
                 '455.121,21'
             );
         });
 
         it('should use US as default local', function() {
-            expect(number_format(455121.213, 1)).to.equal('455,121.2');
+            expect(number_format(455121.213, 1)).toEqual('455,121.2');
         });
 
         it('should extend the number to the precision if needed', function() {
-            expect(number_format(455121, 1)).to.equal('455,121.0');
-            expect(number_format(455121.01, 5)).to.equal('455,121.01000');
+            expect(number_format(455121, 1)).toEqual('455,121.0');
+            expect(number_format(455121.01, 5)).toEqual('455,121.01000');
         });
 
         it('should default to 0 precision', function() {
-            expect(number_format(455121.213)).to.equal('455,121');
+            expect(number_format(455121.213)).toEqual('455,121');
         });
 
         it('should return 0 on invalid input', function() {
-            expect(number_format('hello', 1)).to.equal('0.0');
+            expect(number_format('hello', 1)).toEqual('0.0');
         });
     });
 
     describe('format filter', function() {
         it('should insert strings', function() {
-            expect(format('Hello %s!', 'world')).to.equal('Hello world!');
+            expect(format('Hello %s!', 'world')).toEqual('Hello world!');
         });
 
         it('should format numbers', function() {
-            expect(format('%01.2f', 123.1)).to.equal('123.10');
-            expect(format('%d', 123456789012345)).to.equal('123456789012345');
+            expect(format('%01.2f', 123.1)).toEqual('123.10');
+            expect(format('%d', 123456789012345)).toEqual('123456789012345');
 
             const n = 43951789;
             const u = -n;
             const c = 65;
 
-            expect(format("%%b = '%b'", n)).to.equal(
+            expect(format("%%b = '%b'", n)).toEqual(
                 "%b = '10100111101010011010101101'"
             );
-            expect(format("%%c = '%c'", c)).to.equal("%c = 'A'");
-            expect(format("%%d = '%d'", c)).to.equal("%d = '65'");
-            expect(format("%%i = '%i'", c)).to.equal("%i = '65'");
-            expect(format("%%i = '%i'", '')).to.equal("%i = '0'");
-            expect(format("%%e = '%e'", n)).to.equal("%e = '4.395179e+7'");
-            expect(format("%%u = '%u'", n)).to.equal("%u = '43951789'");
-            expect(format("%%u = '%u'", u)).to.equal("%u = '4251015507'");
-            expect(format("%%f = '%f'", n)).to.equal("%f = '43951789.000000'");
-            expect(format("%%f = '%f'", u)).to.equal("%f = '-43951789.000000'");
-            expect(format("%%F = '%F'", n)).to.equal("%F = '43951789.000000'");
-            expect(format("%%g = '%g'", n)).to.equal("%g = '43951789'");
-            expect(format("%%G = '%G'", n)).to.equal("%G = '43951789'");
-            expect(format("%%f = '%.2f'", n)).to.equal("%f = '43951789.00'");
-            expect(format("%%f = '%.*f'", 1, n)).to.equal("%f = '43951789.0'");
-            expect(format("%%o = '%o'", n)).to.equal("%o = '247523255'");
-            expect(format("%%s = '%s'", n)).to.equal("%s = '43951789'");
-            expect(format("%%x = '%x'", n)).to.equal("%x = '29ea6ad'");
-            expect(format("%%X = '%X'", n)).to.equal("%X = '29EA6AD'");
-            expect(format("%%+d = '%+d'", n)).to.equal("%+d = '+43951789'");
-            expect(format("%%+d = '% d'", n)).to.equal("%+d = ' 43951789'");
-            expect(format("%%+d = '%+d'", u)).to.equal("%+d = '-43951789'");
+            expect(format("%%c = '%c'", c)).toEqual("%c = 'A'");
+            expect(format("%%d = '%d'", c)).toEqual("%d = '65'");
+            expect(format("%%i = '%i'", c)).toEqual("%i = '65'");
+            expect(format("%%i = '%i'", '')).toEqual("%i = '0'");
+            expect(format("%%e = '%e'", n)).toEqual("%e = '4.395179e+7'");
+            expect(format("%%u = '%u'", n)).toEqual("%u = '43951789'");
+            expect(format("%%u = '%u'", u)).toEqual("%u = '4251015507'");
+            expect(format("%%f = '%f'", n)).toEqual("%f = '43951789.000000'");
+            expect(format("%%f = '%f'", u)).toEqual("%f = '-43951789.000000'");
+            expect(format("%%F = '%F'", n)).toEqual("%F = '43951789.000000'");
+            expect(format("%%g = '%g'", n)).toEqual("%g = '43951789'");
+            expect(format("%%G = '%G'", n)).toEqual("%G = '43951789'");
+            expect(format("%%f = '%.2f'", n)).toEqual("%f = '43951789.00'");
+            expect(format("%%f = '%.*f'", 1, n)).toEqual("%f = '43951789.0'");
+            expect(format("%%o = '%o'", n)).toEqual("%o = '247523255'");
+            expect(format("%%s = '%s'", n)).toEqual("%s = '43951789'");
+            expect(format("%%x = '%x'", n)).toEqual("%x = '29ea6ad'");
+            expect(format("%%X = '%X'", n)).toEqual("%X = '29EA6AD'");
+            expect(format("%%+d = '%+d'", n)).toEqual("%+d = '+43951789'");
+            expect(format("%%+d = '% d'", n)).toEqual("%+d = ' 43951789'");
+            expect(format("%%+d = '%+d'", u)).toEqual("%+d = '-43951789'");
 
-            expect(() => format("%%f = '%*.*f'", 1, n)).to.throw(
+            expect(() => format("%%f = '%*.*f'", 1, n)).toThrowError(
                 /toFixed\(\) digits argument must be between 0 and (20|100)/
             );
         });
 
         it('should add padding', function() {
-            expect(format('[%10s]', 'monkey')).to.equal('[    monkey]');
-            expect(format('[%*s]', 10, 'monkey')).to.equal('[    monkey]');
-            expect(format('[%*s]', -10, 'monkey')).to.equal('[monkey    ]');
-            expect(format('[%-10s]', 'monkey')).to.equal('[monkey    ]');
-            expect(format('[%10.10s]', 'many monkeys')).to.equal(
-                '[many monke]'
-            );
-            expect(format("[%'#10s]", 'monkey')).to.equal('[####monkey]');
-            expect(format('%-03s', 'E')).to.equal('E00');
+            expect(format('[%10s]', 'monkey')).toEqual('[    monkey]');
+            expect(format('[%*s]', 10, 'monkey')).toEqual('[    monkey]');
+            expect(format('[%*s]', -10, 'monkey')).toEqual('[monkey    ]');
+            expect(format('[%-10s]', 'monkey')).toEqual('[monkey    ]');
+            expect(format('[%10.10s]', 'many monkeys')).toEqual('[many monke]');
+            expect(format("[%'#10s]", 'monkey')).toEqual('[####monkey]');
+            expect(format('%-03s', 'E')).toEqual('E00');
 
-            expect(() => format('[%*s]', 'fun', 'monkey')).to.throw(
-                'sprintf: (minimum-)width must be finite'
+            expect(() => format('[%*s]', 'fun', 'monkey')).toThrowError(
+                new Error('sprintf: (minimum-)width must be finite')
             );
         });
 
         it('should swap arguments', function() {
-            expect(format('%2$s %1$s!', 'world', 'Hello')).to.equal(
+            expect(format('%2$s %1$s!', 'world', 'Hello')).toEqual(
                 'Hello world!'
             );
             expect(
                 format('The %2$s contains %1$04d monkeys', 12000, 'zoo')
-            ).to.equal('The zoo contains 12000 monkeys');
+            ).toEqual('The zoo contains 12000 monkeys');
             expect(
                 format('The %2$s contains %1$04d monkeys', 120, 'zoo')
-            ).to.equal('The zoo contains 0120 monkeys');
+            ).toEqual('The zoo contains 0120 monkeys');
         });
 
         it('should ignore invalid options', function() {
-            expect(format('Hello %a!', 'world')).to.equal('Hello %a!');
+            expect(format('Hello %a!', 'world')).toEqual('Hello %a!');
         });
     });
 
@@ -406,105 +403,107 @@ describe('Twig filter runtime', function() {
         time.setSeconds(45);
         const unixTime = Math.floor(time.getTime() / 1000);
         it('should convert relative timestamps', function() {
-            expect(strtotime('+1 day', now)).to.equal(1129719600);
-            expect(strtotime('+1 week 2 days 4 hours 2 seconds', now)).to.equal(
+            expect(strtotime('+1 day', now)).toEqual(1129719600);
+            expect(strtotime('+1 week 2 days 4 hours 2 seconds', now)).toEqual(
                 1130425202
             );
             expect(
                 strtotime('+1 day 1 week 2 days 4 hours 2 seconds', now)
-            ).to.equal(1130511602);
-            expect(strtotime('last month', now)).to.equal(1127041200);
-            expect(strtotime('next Thursday', now)).to.equal(1129806000);
-            expect(strtotime('last Monday', now)).to.equal(1129546800);
-            expect(strtotime('now', now)).to.equal(now);
+            ).toEqual(1130511602);
+            expect(strtotime('last month', now)).toEqual(1127041200);
+            expect(strtotime('next Thursday', now)).toEqual(1129806000);
+            expect(strtotime('last Monday', now)).toEqual(1129546800);
+            expect(strtotime('now', now)).toEqual(now);
 
-            expect(strtotime('12.06.45', now)).to.equal(unixTime);
-            expect(strtotime('12:06:45', now)).to.equal(unixTime);
+            expect(strtotime('12.06.45', now)).toEqual(unixTime);
+            expect(strtotime('12:06:45', now)).toEqual(unixTime);
         });
 
         it('should convert dates after 2000', function() {
-            expect(strtotime('10 September 09')).to.equal(1252537200);
-            expect(strtotime('10 September 2009')).to.equal(1252537200);
-            expect(strtotime('2009-09-10', now)).to.equal(1252537200);
-            expect(strtotime('2009/09/10', now)).to.equal(1252537200);
-            expect(strtotime('10-09-2009', now)).to.equal(1252537200);
-            expect(strtotime('10.09.2009', now)).to.equal(1252537200);
-            expect(strtotime('09/10/2009', now)).to.equal(1252537200);
-            expect(strtotime('09-09-10', now)).to.equal(1252537200);
-            expect(strtotime('09/10/09', now)).to.equal(1252537200);
+            expect(strtotime('10 September 09')).toEqual(1252537200);
+            expect(strtotime('10 September 2009')).toEqual(1252537200);
+            expect(strtotime('2009-09-10', now)).toEqual(1252537200);
+            expect(strtotime('2009/09/10', now)).toEqual(1252537200);
+            expect(strtotime('10-09-2009', now)).toEqual(1252537200);
+            expect(strtotime('10.09.2009', now)).toEqual(1252537200);
+            expect(strtotime('09/10/2009', now)).toEqual(1252537200);
+            expect(strtotime('09-09-10', now)).toEqual(1252537200);
+            expect(strtotime('09/10/09', now)).toEqual(1252537200);
         });
 
         it('should convert dates before 2000', function() {
-            expect(strtotime('10 September 79', now)).to.equal(305766000);
-            expect(strtotime('10 September 1979', now)).to.equal(305766000);
-            expect(strtotime('1979-09-10', now)).to.equal(305766000);
-            expect(strtotime('1979/09/10', now)).to.equal(305766000);
-            expect(strtotime('10-09-1979', now)).to.equal(305766000);
-            expect(strtotime('10.09.1979', now)).to.equal(305766000);
-            expect(strtotime('09/10/1979', now)).to.equal(305766000);
-            expect(strtotime('79-09-10', now)).to.equal(305766000);
-            expect(strtotime('10.09.79', now)).to.equal(305766000);
-            expect(strtotime('09/10/79', now)).to.equal(305766000);
+            expect(strtotime('10 September 79', now)).toEqual(305766000);
+            expect(strtotime('10 September 1979', now)).toEqual(305766000);
+            expect(strtotime('1979-09-10', now)).toEqual(305766000);
+            expect(strtotime('1979/09/10', now)).toEqual(305766000);
+            expect(strtotime('10-09-1979', now)).toEqual(305766000);
+            expect(strtotime('10.09.1979', now)).toEqual(305766000);
+            expect(strtotime('09/10/1979', now)).toEqual(305766000);
+            expect(strtotime('79-09-10', now)).toEqual(305766000);
+            expect(strtotime('10.09.79', now)).toEqual(305766000);
+            expect(strtotime('09/10/79', now)).toEqual(305766000);
         });
 
         it('should convert timestamps', function() {
-            expect(strtotime('2009-05-04 08:30:00 GMT')).to.equal(1241425800);
-            expect(strtotime('2009-05-04 08:30:00+00')).to.equal(1241425800);
-            expect(strtotime('2009-05-04 08:30:00+02:00')).to.equal(1241418600);
-            expect(strtotime('2009-05-04 08:30:00z')).to.equal(1241425800);
+            expect(strtotime('2009-05-04 08:30:00 GMT')).toEqual(1241425800);
+            expect(strtotime('2009-05-04 08:30:00+00')).toEqual(1241425800);
+            expect(strtotime('2009-05-04 08:30:00+02:00')).toEqual(1241418600);
+            expect(strtotime('2009-05-04 08:30:00z')).toEqual(1241425800);
         });
 
         it('should return false when given an empty string', function() {
-            expect(strtotime('')).to.equal(false);
+            expect(strtotime('')).toBeFalsy();
         });
 
         it('should return false when given invalid input', function() {
-            expect(strtotime('1801/09/10', now)).to.equal(false);
-            expect(strtotime('1979-13-10', now)).to.equal(false);
-            expect(strtotime('1979/13/10', now)).to.equal(false);
+            expect(strtotime('1801/09/10', now)).toBeFalsy();
+            expect(strtotime('1979-13-10', now)).toBeFalsy();
+            expect(strtotime('1979/13/10', now)).toBeFalsy();
         });
     });
 
     describe('trim filter', function() {
         it('should fallback to native trim', function() {
-            expect(trim('  melody  ')).to.equal('melody');
+            expect(trim('  melody  ')).toEqual('melody');
         });
 
         it('should correctly trim one character', function() {
-            expect(trim('--melody--', '-', 'left')).to.equal('melody--');
-            expect(trim('--melody--', '-', 'right')).to.equal('--melody');
-            expect(trim('--melody--', '-', 'both')).to.equal('melody');
-            expect(trim('--mel--ody--', '-', 'both')).to.equal('mel--ody');
+            expect(trim('--melody--', '-', 'left')).toEqual('melody--');
+            expect(trim('--melody--', '-', 'right')).toEqual('--melody');
+            expect(trim('--melody--', '-', 'both')).toEqual('melody');
+            expect(trim('--mel--ody--', '-', 'both')).toEqual('mel--ody');
         });
 
         it('should correctly trim multiple characters', function() {
-            expect(trim('(()melody())', '()', 'left')).to.equal('melody())');
-            expect(trim('(()melody())', '()', 'right')).to.equal('(()melody');
-            expect(trim('(()melody())', '()', 'both')).to.equal('melody');
-            expect(trim('(()me(l)ody())', '()', 'both')).to.equal('me(l)ody');
+            expect(trim('(()melody())', '()', 'left')).toEqual('melody())');
+            expect(trim('(()melody())', '()', 'right')).toEqual('(()melody');
+            expect(trim('(()melody())', '()', 'both')).toEqual('melody');
+            expect(trim('(()me(l)ody())', '()', 'both')).toEqual('me(l)ody');
         });
 
         it('should not change the source string if not needed', function() {
-            expect(trim('(()melody())', '-my', 'both')).to.equal(
-                '(()melody())'
-            );
+            expect(trim('(()melody())', '-my', 'both')).toEqual('(()melody())');
         });
 
         it('should work with empty strings', function() {
-            expect(trim('', '-', 'both')).to.equal('');
-            expect(trim('', '-', 'left')).to.equal('');
-            expect(trim('', '-', 'right')).to.equal('');
-            expect(trim('  melody  ', '', 'both')).to.equal('  melody  ');
+            expect(trim('', '-', 'both')).toEqual('');
+            expect(trim('', '-', 'left')).toEqual('');
+            expect(trim('', '-', 'right')).toEqual('');
+            expect(trim('  melody  ', '', 'both')).toEqual('  melody  ');
         });
 
         it('should return an empty string if every character is removed', function() {
-            expect(trim('----', '-', 'both')).to.equal('');
-            expect(trim('----', '-', 'left')).to.equal('');
-            expect(trim('----', '-', 'right')).to.equal('');
+            expect(trim('----', '-', 'both')).toEqual('');
+            expect(trim('----', '-', 'left')).toEqual('');
+            expect(trim('----', '-', 'right')).toEqual('');
         });
 
         it('should error if side is not valid', function() {
-            expect(() => trim('----', '-', 'foobar')).to.throw();
+            const error =
+                'Filter "trim". Invalid value foobar for parameter "side". Valid values are "both", "left", "right".';
+            expect(() => trim('----', '-', 'foobar')).toThrowError(
+                new Error(error)
+            );
         });
     });
 });

--- a/packages/melody-runtime/__tests__/FunctionsSpec.js
+++ b/packages/melody-runtime/__tests__/FunctionsSpec.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from 'chai';
 
 import { random, min, max, cycle, attribute } from '../src/functions';
 
@@ -23,75 +22,75 @@ describe('Twig function runtime', function() {
             const input = 0;
             const expected = 0;
             const actual = random(input);
-            expect(actual).to.eql(expected);
+            expect(actual).toEqual(expected);
         });
 
         it('should select an element from an array', function() {
             const input = ['a', 'b'];
             const actual = random(input);
-            expect(actual).to.be.oneOf(input);
+            expect(input).toContain(actual);
         });
     });
 
     describe('min', function() {
         it('should accept varargs', function() {
             const actual = min(1, 2, 3, 4, 5, 6, 7);
-            expect(actual).to.equal(1);
+            expect(actual).toEqual(1);
         });
 
         it('should accept an array', function() {
             const input = [1, 2, 3, 4, 5, 6, 7];
             const actual = min(input);
-            expect(actual).to.equal(1);
+            expect(actual).toEqual(1);
         });
 
         it('should select the lowest value in an object', function() {
             const input = { a: 1, b: 2 };
             const actual = min(input);
-            expect(actual).to.equal(1);
+            expect(actual).toEqual(1);
         });
     });
 
     describe('max', function() {
         it('should accept varargs', function() {
             const actual = max(1, 2, 3, 4, 5, 6, 7);
-            expect(actual).to.equal(7);
+            expect(actual).toEqual(7);
         });
 
         it('should accept an array', function() {
             const input = [1, 2, 3, 4, 5, 6, 7];
             const actual = max(input);
-            expect(actual).to.equal(7);
+            expect(actual).toEqual(7);
         });
 
         it('should select the lowest value in an object', function() {
             const input = { a: 1, b: 2 };
             const actual = max(input);
-            expect(actual).to.equal(2);
+            expect(actual).toEqual(2);
         });
     });
 
     describe('cycle', function() {
         it('should return the element at the given index', function() {
             const input = ['a', 'b', 'c'];
-            expect(cycle(input, 0)).to.equal('a');
-            expect(cycle(input, 1)).to.equal('b');
-            expect(cycle(input, 2)).to.equal('c');
-            expect(cycle(input, 3)).to.equal('a');
-            expect(cycle(input, 4)).to.equal('b');
-            expect(cycle(input, 5)).to.equal('c');
-            expect(cycle(input, 6)).to.equal('a');
+            expect(cycle(input, 0)).toEqual('a');
+            expect(cycle(input, 1)).toEqual('b');
+            expect(cycle(input, 2)).toEqual('c');
+            expect(cycle(input, 3)).toEqual('a');
+            expect(cycle(input, 4)).toEqual('b');
+            expect(cycle(input, 5)).toEqual('c');
+            expect(cycle(input, 6)).toEqual('a');
         });
     });
 
     describe('attribute', function() {
         it('should return an array index', function() {
-            expect(attribute(['a', 'b', 'c'], 1)).to.equal('b');
+            expect(attribute(['a', 'b', 'c'], 1)).toEqual('b');
         });
 
         it('should return the value of a property', function() {
             const input = { a: 42 };
-            expect(attribute(input, 'a')).to.equal(42);
+            expect(attribute(input, 'a')).toEqual(42);
         });
 
         it('should evaluate a function, forwarding the arguments', function() {
@@ -100,7 +99,7 @@ describe('Twig function runtime', function() {
                     return b + c;
                 },
             };
-            expect(attribute(input, 'a', [2, 3])).to.equal(5);
+            expect(attribute(input, 'a', [2, 3])).toEqual(5);
         });
 
         it('should use a getter if available', function() {
@@ -109,7 +108,7 @@ describe('Twig function runtime', function() {
                     return 5;
                 },
             };
-            expect(attribute(input, 'aValue')).to.equal(5);
+            expect(attribute(input, 'aValue')).toEqual(5);
         });
 
         it('should use an is property if available', function() {
@@ -118,12 +117,12 @@ describe('Twig function runtime', function() {
                     return true;
                 },
             };
-            expect(attribute(input, 'aValue')).to.equal(true);
+            expect(attribute(input, 'aValue')).toBeTruthy();
         });
 
         it('should return undefined on mismatch', function() {
             const input = {};
-            expect(attribute(input, 'toString')).to.equal(undefined);
+            expect(attribute(input, 'toString')).toBeUndefined();
         });
     });
 });

--- a/packages/melody-runtime/__tests__/HelperSpec.js
+++ b/packages/melody-runtime/__tests__/HelperSpec.js
@@ -13,33 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
 import { isEmpty, inheritBlocks } from '../src/helpers';
 
 describe('Runtime/Helpers', function() {
     describe('isEmpty', function() {
         it('should return true for an empty array', function() {
-            assert.equal(isEmpty([]), true);
+            expect(isEmpty([])).toBeTruthy();
         });
 
         it('should return false for a non-empty array', function() {
-            assert.equal(isEmpty([42]), false);
+            expect(isEmpty([42])).toBeFalsy();
         });
 
         it('should return true for null', function() {
-            assert.equal(isEmpty(null), true);
+            expect(isEmpty(null)).toBeTruthy();
         });
 
         it('should return true for undefined', function() {
-            assert.equal(isEmpty(undefined), true);
+            expect(isEmpty(undefined)).toBeTruthy();
         });
 
         it('should return false for an empty object', function() {
-            assert.equal(isEmpty({}), false);
+            expect(isEmpty({})).toBeFalsy();
         });
 
         it('should return false for 0', function() {
-            assert.equal(isEmpty(0), false);
+            expect(isEmpty(0)).toBeFalsy();
         });
     });
 
@@ -48,8 +47,8 @@ describe('Runtime/Helpers', function() {
             const template = { render: 1 };
             const used = { renderFoo: 2, render: 3 };
             inheritBlocks(template, used);
-            assert.equal(template.renderFoo, 2);
-            assert.equal(template.render, 1);
+            expect(template.renderFoo).toEqual(2);
+            expect(template.render).toEqual(1);
         });
 
         it('copies block rendering methods with mappings', function() {
@@ -57,10 +56,10 @@ describe('Runtime/Helpers', function() {
             const used = { renderFoo: 2, render: 3, renderFoobar: 4 };
             const mapping = { renderFoo: 'renderBar' };
             inheritBlocks(template, used, mapping);
-            assert.equal(template.renderFoo, undefined);
-            assert.equal(template.renderFoobar, undefined);
-            assert.equal(template.renderBar, 2);
-            assert.equal(template.render, 1);
+            expect(template.renderFoo).toBeUndefined();
+            expect(template.renderFoobar).toBeUndefined();
+            expect(template.renderBar).toEqual(2);
+            expect(template.render).toEqual(1);
         });
 
         it('ignores prototype methods', function() {
@@ -71,8 +70,8 @@ describe('Runtime/Helpers', function() {
             const used = { renderFoo: 2, render: 3 };
             inheritBlocks(template, used);
 
-            assert.equal(template.renderFoo, 2);
-            assert.equal(template.fooBar, undefined);
+            expect(template.renderFoo).toEqual(2);
+            expect(template.fooBar).toBeUndefined();
 
             Object.prototype.fooBar = bak;
         });

--- a/packages/melody-util/__tests__/MiddlewareSpec.js
+++ b/packages/melody-util/__tests__/MiddlewareSpec.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
-
 import { createComponent } from 'melody-component';
 import { applyMiddleware } from '../src';
 import thunkMiddleware from 'redux-thunk';
@@ -45,10 +43,10 @@ describe('Middleware', function() {
         const el = document.createElement('div');
         const Component = createComponent(tpl, reducer);
         const comp = new Component(el);
-        assert(!comp.getState(), 'Component does not have state');
+        expect(!comp.getState()).toBeTruthy();
         comp.dispatch({ type: 'count', payload: { msg: 'hello' } });
-        assert(!!comp.getState(), 'Component has state');
-        assert.equal(comp.getState().msg, 'hello');
+        expect(!!comp.getState()).toBeTruthy();
+        expect(comp.getState().msg).toEqual('hello');
     });
 
     it('can call dispatch as often as it wants to', function() {
@@ -72,12 +70,12 @@ describe('Middleware', function() {
         const Component = createComponent(
             tpl,
             reducer,
-            applyMiddleware(doubleDispatch),
+            applyMiddleware(doubleDispatch)
         );
         const comp = new Component(el);
         comp.dispatch({ type: 'count' });
-        assert.equal(reducerCalled, 2, 'Reducer was called twice');
-        assert.equal(2, comp.getState().count, 'Action is reduced twice');
+        expect(reducerCalled).toEqual(2);
+        expect(2).toEqual(comp.getState().count);
     });
 
     it('can filter dispatch calls', function() {
@@ -91,14 +89,14 @@ describe('Middleware', function() {
         const Component = createComponent(
             tpl,
             countingReducer,
-            applyMiddleware(filterType('inc')),
+            applyMiddleware(filterType('inc'))
         );
         const comp = new Component(el);
         comp.dispatch({ type: 'inc' });
         comp.dispatch({ type: 'inc' });
         comp.dispatch({ type: 'dec' });
         comp.dispatch({ type: 'inc' });
-        assert.equal(3, comp.getState().count);
+        expect(3).toEqual(comp.getState().count);
     });
 
     describe('thunk middleware', function() {
@@ -107,7 +105,7 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(thunkMiddleware, null, undefined, false),
+                applyMiddleware(thunkMiddleware, null, undefined, false)
             );
             const comp = new Component(el);
             comp.dispatch(dispatch => {
@@ -115,7 +113,7 @@ describe('Middleware', function() {
                 dispatch({ type: 'dec' });
                 dispatch({ type: 'inc' });
             });
-            assert.equal(1, comp.getState().count);
+            expect(1).toEqual(comp.getState().count);
         });
 
         it('passes getState to the actor', function() {
@@ -123,18 +121,18 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(thunkMiddleware),
+                applyMiddleware(thunkMiddleware)
             );
             const comp = new Component(el);
             comp.dispatch((dispatch, getState) => {
                 dispatch({ type: 'inc' });
-                assert.equal(1, getState().count, 'After first increment');
+                expect(1).toEqual(getState().count);
                 dispatch({ type: 'dec' });
-                assert.equal(0, getState().count, 'After decrement');
+                expect(0).toEqual(getState().count);
                 dispatch({ type: 'inc' });
-                assert.equal(1, getState().count, 'After last increment');
+                expect(1).toEqual(getState().count);
             });
-            assert.equal(1, comp.getState().count);
+            expect(1).toEqual(comp.getState().count);
         });
 
         it('can be async', function(done) {
@@ -142,36 +140,23 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(thunkMiddleware),
+                applyMiddleware(thunkMiddleware)
             );
             const comp = new Component(el);
-            comp
-                .dispatch(
-                    (dispatch, getState) =>
-                        new Promise((resolve, reject) => {
-                            dispatch({ type: 'inc' });
-                            assert.equal(
-                                1,
-                                getState().count,
-                                'After first increment',
-                            );
-                            dispatch({ type: 'dec' });
-                            assert.equal(
-                                0,
-                                getState().count,
-                                'After decrement',
-                            );
-                            dispatch({ type: 'inc' });
-                            assert.equal(
-                                1,
-                                getState().count,
-                                'After last increment',
-                            );
-                            resolve();
-                        }),
-                )
+            comp.dispatch(
+                (dispatch, getState) =>
+                    new Promise((resolve, reject) => {
+                        dispatch({ type: 'inc' });
+                        expect(1).toEqual(getState().count);
+                        dispatch({ type: 'dec' });
+                        expect(0).toEqual(getState().count);
+                        dispatch({ type: 'inc' });
+                        expect(1).toEqual(getState().count);
+                        resolve();
+                    })
+            )
                 .then(() => {
-                    assert.equal(1, comp.getState().count);
+                    expect(1).toEqual(comp.getState().count);
                 })
                 .then(done, done);
         });
@@ -186,14 +171,14 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(thunkMiddleware, loggerMiddleware),
+                applyMiddleware(thunkMiddleware, loggerMiddleware)
             );
             const comp = new Component(el);
             comp.dispatch(dispatch => dispatch({ type: 'inc' }));
             expect(JSON.stringify(log)).toEqual(
-                JSON.stringify([{ type: 'inc' }]),
+                JSON.stringify([{ type: 'inc' }])
             );
-            assert.equal(1, log.length, 'should have logged once');
+            expect(1).toEqual(log.length);
         });
     });
 
@@ -203,20 +188,19 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(promiseMiddleware),
+                applyMiddleware(promiseMiddleware)
             );
             const comp = new Component(el);
-            comp
-                .dispatch(
-                    new Promise(resolve => {
-                        resolve({ type: 'inc' });
-                    }),
-                )
+            comp.dispatch(
+                new Promise(resolve => {
+                    resolve({ type: 'inc' });
+                })
+            )
                 .then(() => {
-                    assert.equal(1, comp.getState().count);
+                    expect(1).toEqual(comp.getState().count);
                 })
                 .then(done, done);
-            assert.equal(0, comp.getState().count);
+            expect(0).toEqual(comp.getState().count);
         });
 
         it('ignores rejected promises', function(done) {
@@ -224,23 +208,22 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(promiseMiddleware),
+                applyMiddleware(promiseMiddleware)
             );
             const comp = new Component(el);
-            comp
-                .dispatch(
-                    new Promise((resolve, reject) => {
-                        reject({ reason: 'just testing' });
-                    }),
-                )
+            comp.dispatch(
+                new Promise((resolve, reject) => {
+                    reject({ reason: 'just testing' });
+                })
+            )
                 .then(() => {
-                    assert.equal(1, comp.getState().count);
+                    expect(1).toEqual(comp.getState().count);
                 })
                 .catch(err => {
-                    assert.equal(err.reason, 'just testing');
+                    expect(err.reason).toEqual('just testing');
                 })
                 .then(done, done);
-            assert.equal(0, comp.getState().count);
+            expect(0).toEqual(comp.getState().count);
         });
     });
 
@@ -250,20 +233,19 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(promiseMiddleware, thunkMiddleware),
+                applyMiddleware(promiseMiddleware, thunkMiddleware)
             );
             const comp = new Component(el);
-            comp
-                .dispatch(
-                    new Promise(resolve => {
-                        resolve({ type: 'inc' });
-                    }),
-                )
+            comp.dispatch(
+                new Promise(resolve => {
+                    resolve({ type: 'inc' });
+                })
+            )
                 .then(() => {
-                    assert.equal(1, comp.getState().count);
+                    expect(1).toEqual(comp.getState().count);
                 })
                 .then(done, done);
-            assert.equal(0, comp.getState().count);
+            expect(0).toEqual(comp.getState().count);
         });
 
         it('ignores rejected promises', function(done) {
@@ -271,23 +253,22 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(promiseMiddleware, thunkMiddleware),
+                applyMiddleware(promiseMiddleware, thunkMiddleware)
             );
             const comp = new Component(el);
-            comp
-                .dispatch(
-                    new Promise((resolve, reject) => {
-                        reject({ reason: 'just testing' });
-                    }),
-                )
+            comp.dispatch(
+                new Promise((resolve, reject) => {
+                    reject({ reason: 'just testing' });
+                })
+            )
                 .then(() => {
-                    assert.equal(1, comp.getState().count);
+                    expect(1).toEqual(comp.getState().count);
                 })
                 .catch(err => {
-                    assert.equal(err.reason, 'just testing');
+                    expect(err.reason).toEqual('just testing');
                 })
                 .then(done, done);
-            assert.equal(0, comp.getState().count);
+            expect(0).toEqual(comp.getState().count);
         });
 
         it('accepts a function', function() {
@@ -295,7 +276,7 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(promiseMiddleware, thunkMiddleware),
+                applyMiddleware(promiseMiddleware, thunkMiddleware)
             );
             const comp = new Component(el);
             comp.dispatch(dispatch => {
@@ -303,7 +284,7 @@ describe('Middleware', function() {
                 dispatch({ type: 'dec' });
                 dispatch({ type: 'inc' });
             });
-            assert.equal(1, comp.getState().count);
+            expect(1).toEqual(comp.getState().count);
         });
 
         it('provides access to state', function() {
@@ -311,18 +292,18 @@ describe('Middleware', function() {
             const Component = createComponent(
                 tpl,
                 countingReducer,
-                applyMiddleware(promiseMiddleware, thunkMiddleware),
+                applyMiddleware(promiseMiddleware, thunkMiddleware)
             );
             const comp = new Component(el);
             comp.dispatch((dispatch, getState) => {
                 dispatch({ type: 'inc' });
-                assert.equal(1, getState().count, 'After first increment');
+                expect(1).toEqual(getState().count);
                 dispatch({ type: 'dec' });
-                assert.equal(0, getState().count, 'After decrement');
+                expect(0).toEqual(getState().count);
                 dispatch({ type: 'inc' });
-                assert.equal(1, getState().count, 'After last increment');
+                expect(1).toEqual(getState().count);
             });
-            assert.equal(1, comp.getState().count);
+            expect(1).toEqual(comp.getState().count);
         });
     });
 });

--- a/packages/melody-util/__tests__/ReducerSpec.js
+++ b/packages/melody-util/__tests__/ReducerSpec.js
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
+
 import { RECEIVE_PROPS } from 'melody-component';
-
 import { createActionReducer, dispatchToState, exposeToState } from '../src';
-
-import sinon from 'sinon';
 
 describe('Reducer utils', function() {
     describe('createActionReducer', function() {
@@ -37,16 +34,29 @@ describe('Reducer utils', function() {
                     },
                     noop(state, action) {},
                 },
-                { count: 5 },
+                { count: 5 }
             );
-            assert.equal(reducer({ count: 1 }, { type: 'inc' }).count, 2);
-            assert.equal(reducer({ count: 2 }, { type: 'inc' }).count, 3);
-            assert.equal(reducer({ count: 2 }, { type: 'dec' }).count, 1);
-            assert.equal(reducer({ count: 2 }, { type: 'noop' }).count, 2);
-            assert.equal(reducer({ count: 2 }, { type: 'unknown' }).count, 2);
-            assert.equal(reducer(undefined, { type: 'unknown' }).count, 5);
-            assert.equal(reducer(undefined, { type: 'inc' }).count, 6);
-            assert.equal(reducer(undefined, { type: 'noop' }).count, 5);
+
+            expect(reducer({ count: 1 }, { type: 'inc' })).toEqual({
+                count: 2,
+            });
+            expect(reducer({ count: 2 }, { type: 'inc' })).toEqual({
+                count: 3,
+            });
+            expect(reducer({ count: 2 }, { type: 'dec' })).toEqual({
+                count: 1,
+            });
+            expect(reducer({ count: 2 }, { type: 'noop' })).toEqual({
+                count: 2,
+            });
+            expect(reducer({ count: 2 }, { type: 'unknown' })).toEqual({
+                count: 2,
+            });
+            expect(reducer(undefined, { type: 'unknown' })).toEqual({
+                count: 5,
+            });
+            expect(reducer(undefined, { type: 'inc' })).toEqual({ count: 6 });
+            expect(reducer(undefined, { type: 'noop' })).toEqual({ count: 5 });
         });
     });
 
@@ -57,33 +67,33 @@ describe('Reducer utils', function() {
                     dispatch({ type: 'test' });
                 },
             }));
-            const dispatch = sinon.spy();
+            const dispatch = jest.fn();
 
             const state = reducer(
                 {},
                 {
                     type: 'MELODY/RECEIVE_PROPS',
                     meta: { dispatch },
-                },
+                }
             );
-            assert(typeof state.test === 'function', 'test is a function');
+            expect(typeof state.test).toEqual('function');
             state.test();
-            assert(dispatch.calledOnce);
-            assert(dispatch.calledWith({ type: 'test' }));
+            expect(dispatch).toHaveBeenCalledTimes(1);
+            expect(dispatch).toHaveBeenLastCalledWith({ type: 'test' });
         });
 
         it('should invoke the dispatch mapper only once', function() {
-            const test = sinon.spy();
-            const dispatchMapper = sinon.stub().returns({ test });
+            const test = jest.fn();
+            const dispatchMapper = jest.fn(() => ({ test }));
             const reducer = dispatchToState(dispatchMapper);
-            const dispatch = sinon.spy();
+            const dispatch = jest.fn();
 
             let state = reducer(
                 {},
                 {
                     type: 'MELODY/RECEIVE_PROPS',
                     meta: { dispatch },
-                },
+                }
             );
             state = reducer(state, {
                 type: 'MELODY/RECEIVE_PROPS',
@@ -93,17 +103,15 @@ describe('Reducer utils', function() {
                 type: 'fun',
                 meta: { dispatch },
             });
-            assert(
-                dispatchMapper.calledOnce,
-                'dispatch mapper invoked exactly once',
-            );
-            assert(typeof state.test === 'function', 'test is a function');
+
+            expect(dispatchMapper).toHaveBeenCalledTimes(1);
+            expect(typeof state.test).toEqual('function');
         });
     });
 
     describe('dispatchToState when given an object', function() {
         it('should use the objects methods as action creators', function() {
-            const dispatch = sinon.spy();
+            const dispatch = jest.fn();
             const reducer = dispatchToState({
                 test(payload) {
                     return {
@@ -118,19 +126,20 @@ describe('Reducer utils', function() {
                 {
                     type: 'MELODY/RECEIVE_PROPS',
                     meta: { dispatch },
-                },
+                }
             );
 
             state.test('hello world');
-            assert(dispatch.calledOnce, 'dispatch was invoked once');
-            assert(
-                dispatch.calledWith({ type: 'FOO', payload: 'hello world' }),
-                'dispatch was invoked with correct action',
-            );
+
+            expect(dispatch).toHaveBeenCalledTimes(1);
+            expect(dispatch).toHaveBeenCalledWith({
+                type: 'FOO',
+                payload: 'hello world',
+            });
         });
 
         it('should ignore non-function properties', function() {
-            const dispatch = sinon.spy();
+            const dispatch = jest.fn();
             const reducer = dispatchToState({
                 hello: 'foo',
                 test(payload) {
@@ -146,14 +155,12 @@ describe('Reducer utils', function() {
                 {
                     type: 'MELODY/RECEIVE_PROPS',
                     meta: { dispatch },
-                },
+                }
             );
 
             state.test('hello world');
-            assert(
-                typeof state.hello === 'undefined',
-                'hello should not be copied over',
-            );
+
+            expect(typeof state.hello).toEqual('undefined');
         });
     });
 
@@ -169,7 +176,7 @@ describe('Reducer utils', function() {
                 };
             };
             const reducer = dispatchToState(dispatchMapper);
-            const dispatch = sinon.spy();
+            const dispatch = jest.fn();
 
             let state = reducer(
                 {},
@@ -177,46 +184,39 @@ describe('Reducer utils', function() {
                     type: 'MELODY/RECEIVE_PROPS',
                     meta: { dispatch },
                     payload: { val: 21 },
-                },
+                }
             );
-            assert.equal(counter, 1, 'dispatchMapper called once');
+            expect(counter).toEqual(1);
             state.test();
-            assert(
-                dispatch.calledWith({
-                    type: 'test',
-                    payload: 21,
-                }),
-                'dispatch called with a payload of 21',
-            );
+            expect(dispatch).toHaveBeenCalledWith({
+                type: 'test',
+                payload: 21,
+            });
 
             state = reducer(state, {
                 type: 'MELODY/RECEIVE_PROPS',
                 meta: { dispatch },
                 payload: { val: 42 },
             });
-            assert.equal(counter, 2, 'dispatchMapper called twice');
+
+            expect(counter).toEqual(2);
             state.test();
-            assert(
-                dispatch.calledWith({
-                    type: 'test',
-                    payload: 42,
-                }),
-                'dispatch called with a payload of 21',
-            );
+            expect(dispatch).toHaveBeenCalledWith({
+                type: 'test',
+                payload: 42,
+            });
 
             state = reducer(state, {
                 type: 'fun',
                 payload: { val: 42 },
             });
-            assert.equal(counter, 2, 'dispatchMapper called twice');
+
+            expect(counter).toEqual(2);
             state.test();
-            assert(
-                dispatch.calledWith({
-                    type: 'test',
-                    payload: 42,
-                }),
-                'dispatch called with a payload of 21',
-            );
+            expect(dispatch).toHaveBeenCalledWith({
+                type: 'test',
+                payload: 42,
+            });
         });
     });
     describe('exposeToState', function() {
@@ -252,25 +252,15 @@ describe('Reducer utils', function() {
                     payload: {
                         qux: 'bar',
                     },
-                },
+                }
             );
 
-            assert(state.qux === 'bar', 'passes props to state');
-            assert(
-                typeof state.handleToggle === 'function',
-                'handleToggle is a function',
-            );
-            assert(
-                typeof state.doNotExpose === 'undefined',
-                'only expose given functions',
-            );
+            expect(state.qux).toEqual('bar');
+            expect(typeof state.handleToggle === 'function').toBeTruthy();
+            expect(state.doNotExpose).toBeUndefined();
 
             state.handleToggle();
-            assert.deepEqual(
-                log,
-                [component],
-                'handleToggle is bound to the component',
-            );
+            expect(log).toEqual([component]);
 
             const state2 = finalReducer(state, {
                 type: RECEIVE_PROPS,
@@ -279,11 +269,10 @@ describe('Reducer utils', function() {
                     qux: 'bar',
                 },
             });
-            assert(
-                state.handleToggle === state2.handleToggle,
-                'bound functions get memoized',
-            );
+
+            expect(state.handleToggle).toEqual(state2.handleToggle);
         });
+
         it('should take a default reducer if no reducer was given', function() {
             const finalReducer = exposeToState(['handleToggle']);
             const state = finalReducer(
@@ -294,14 +283,12 @@ describe('Reducer utils', function() {
                     payload: {
                         qux: 'bar',
                     },
-                },
+                }
             );
-            assert(state.qux === 'bar', 'passes props to state');
-            assert(
-                typeof state.handleToggle === 'function',
-                'handleToggle is a function',
-            );
+            expect(state.qux).toEqual('bar');
+            expect(typeof state.handleToggle === 'function').toBeTruthy();
         });
+
         it('should take a ignore actions not known by the default reducer', function() {
             const finalReducer = exposeToState(['handleToggle']);
             const givenState = {};
@@ -312,8 +299,9 @@ describe('Reducer utils', function() {
                     qux: 'bar',
                 },
             });
-            assert.equal(state, givenState);
+            expect(state).toEqual(givenState);
         });
+
         it('should be able to deal with an undefined state in the default reducer even if it does not know the action type', function() {
             const finalReducer = exposeToState(['handleToggle']);
             const state = finalReducer(undefined, {
@@ -325,6 +313,7 @@ describe('Reducer utils', function() {
             });
             expect(state).toEqual({});
         });
+
         it('should be able to deal with an undefined state in the default reducer', function() {
             const finalReducer = exposeToState(['handleToggle']);
             const state = finalReducer(undefined, {
@@ -334,33 +323,34 @@ describe('Reducer utils', function() {
                     qux: 'bar',
                 },
             });
-            assert(state.qux === 'bar', 'passes props to state');
-            assert(
-                typeof state.handleToggle === 'function',
-                'handleToggle is a function',
-            );
+            expect(state.qux).toEqual('bar');
+            expect(typeof state.handleToggle === 'function').toBeTruthy();
         });
+
         it('should throw if given property is not a function', function() {
             const finalReducer = exposeToState(['notAFunction'], reducer);
-            assert.throws(
-                () =>
-                    finalReducer(
-                        {},
-                        { type: RECEIVE_PROPS, meta: component, payload: {} },
-                    ),
-                'Property `notAFunction` is not a function. Only functions can be exposed to the state.',
+            const error = new Error(
+                'Property `notAFunction` is not a function. Only functions can be exposed to the state.'
             );
+            expect(() =>
+                finalReducer(
+                    {},
+                    { type: RECEIVE_PROPS, meta: component, payload: {} }
+                )
+            ).toThrowError(error);
         });
+
         it('should throw if given property is was not found', function() {
             const finalReducer = exposeToState(['notFound'], reducer);
-            assert.throws(
-                () =>
-                    finalReducer(
-                        {},
-                        { type: RECEIVE_PROPS, meta: component, payload: {} },
-                    ),
-                'Property `notFound` was not found on the component.',
+            const error = new Error(
+                'Property `notFound` was not found on the component.'
             );
+            expect(() =>
+                finalReducer(
+                    {},
+                    { type: RECEIVE_PROPS, meta: component, payload: {} }
+                )
+            ).toThrowError(error);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,54 +5,64 @@
 "@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.0.0-beta.47":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
   dependencies:
     "@babel/highlight" "^7.0.0"
 
 "@babel/helper-module-imports@^7.0.0-beta.49":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+  integrity sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
   dependencies:
     "@babel/types" "^7.0.0"
 
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.3.tgz#6c44d1cdac2a7625b624216657d5bc6c107ab436"
+  integrity sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==
   dependencies:
     esutils "^2.0.2"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/jest@^22.0.1":
   version "22.2.3"
-  resolved "http://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
+  integrity sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==
 
 "@types/lodash@^4.14.54":
-  version "4.14.116"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
+  version "4.14.121"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.121.tgz#9327e20d49b95fc2bf983fc2f045b2c6effc80b9"
+  integrity sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==
 
 "@types/node@*":
-  version "10.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
+  version "11.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.5.tgz#011eece9d3f839a806b63973e228f85967b79ed3"
+  integrity sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==
 
 "@types/node@^7.0.7":
-  version "7.0.70"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.70.tgz#688aaeb6e6d374ed016c4dc2c46de695859d6887"
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.10.3.tgz#b85d16331cf5ffe434600816593f86e10ccc0e73"
+  integrity sha512-HeyK+csRk7Khhg9krpMGJeT9pLzjsmiJFHYRzYpPv/dQ5tPclQsbvceiX/HKynRt/9lMLorWUYTbBHC3hRI4sg==
 
 JSONStream@^1.0.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.4.tgz#615bb2adb0cd34c8f4c447b5f6512fa1d8f16a2e"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
@@ -60,94 +70,129 @@ JSONStream@^1.0.4:
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
+  integrity sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==
 
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
 acorn-globals@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.0.tgz#e3b6f8da3c1552a95ae627571f7dd6923bb54103"
+  integrity sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==
   dependencies:
-    acorn "^5.0.0"
+    acorn "^6.0.1"
+    acorn-walk "^6.0.1"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  integrity sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
   dependencies:
     acorn "^3.0.4"
 
+acorn-walk@^6.0.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
+  integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
+
 acorn@^3.0.4:
   version "3.3.0"
-  resolved "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3:
+acorn@^5.5.0, acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+
+acorn@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
+  integrity sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
 
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
+  integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+  integrity sha1-MU3QpLM2j609/NxU7eYXG4htrzw=
 
 ajv@^4.7.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
+  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.3.0:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+ajv@^6.5.5:
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.2.tgz#4927adb83e7f48e5a32b45729744c71ec39c9c7b"
+  integrity sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==
   dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
+    fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+  integrity sha1-06ioOzGapneTZisT52HHkRQiMG4=
 
-ansi-escapes@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
 ansi-styles@^3.1.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
 ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
+  integrity sha1-qCJQ3bABXponyoLoLqYDu/pF768=
 
 ansi-yellow@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ansi-yellow/-/ansi-yellow-0.1.1.tgz#cb9356f2f46c732f0e3199e6102955a77da83c1d"
+  integrity sha1-y5NW8vRscy8OMZnmEClVp32oPB0=
   dependencies:
     ansi-wrap "0.1.0"
 
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
+  integrity sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==
   dependencies:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
@@ -155,6 +200,7 @@ anymatch@^1.3.0:
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+  integrity sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
@@ -162,24 +208,29 @@ anymatch@^2.0.0:
 app-root-path@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
+  integrity sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=
 
 app-root-path@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.1.0.tgz#98bf6599327ecea199309866e8140368fd2e646a"
+  integrity sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo=
 
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+  integrity sha1-126/jKlNJ24keja61EpLdKthGZE=
   dependencies:
     default-require-extensions "^1.0.0"
 
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
+  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
@@ -187,12 +238,14 @@ are-we-there-yet@~1.1.2:
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
 arr-diff@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
+  integrity sha1-aHwydYFjWI/vfeezb6vklesaOZo=
   dependencies:
     arr-flatten "^1.0.1"
     array-slice "^0.2.3"
@@ -200,62 +253,76 @@ arr-diff@^1.0.1:
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
+  integrity sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=
   dependencies:
     arr-flatten "^1.0.1"
 
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+  integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
 arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
 
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+  integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+  integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
 
 array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
+  integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
 
 array-slice@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
+  integrity sha1-3Tz7gO15c6dRF82sabC5nshhhvU=
 
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
   dependencies:
     array-uniq "^1.0.1"
 
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+  integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
 
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+  integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-arrify@^1.0.0, arrify@^1.0.1:
+arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
+  integrity sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -264,74 +331,85 @@ asn1.js@^4.0.0:
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
     safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
 assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
   dependencies:
     util "0.10.3"
-
-assertion-error@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
 
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+  integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+  integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
 
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
 async@^1.3.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^2.1.4, async@^2.5.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
+  integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
   dependencies:
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 axios@0.15.3:
   version "0.15.3"
-  resolved "http://registry.npmjs.org/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
+  integrity sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=
   dependencies:
     follow-redirects "1.0.0"
 
 axios@^0.16.2:
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.16.2.tgz#ba4f92f17167dfbab40983785454b9ac149c3c6d"
+  integrity sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=
   dependencies:
     follow-redirects "^1.2.3"
     is-buffer "^1.1.5"
@@ -339,6 +417,7 @@ axios@^0.16.2:
 babel-cli@^6.23.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
+  integrity sha1-UCq1SHTX24itALiHoGODzgPQAvE=
   dependencies:
     babel-core "^6.26.0"
     babel-polyfill "^6.26.0"
@@ -360,6 +439,7 @@ babel-cli@^6.23.0:
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
   dependencies:
     chalk "^1.1.3"
     esutils "^2.0.2"
@@ -368,6 +448,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
 babel-core@^6.0.0, babel-core@^6.26.0, babel-core@^6.26.3:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
   dependencies:
     babel-code-frame "^6.26.0"
     babel-generator "^6.26.0"
@@ -392,6 +473,7 @@ babel-core@^6.0.0, babel-core@^6.26.0, babel-core@^6.26.3:
 babel-eslint@^7.1.1:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+  integrity sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=
   dependencies:
     babel-code-frame "^6.22.0"
     babel-traverse "^6.23.1"
@@ -401,6 +483,7 @@ babel-eslint@^7.1.1:
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
+  integrity sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==
   dependencies:
     babel-messages "^6.23.0"
     babel-runtime "^6.26.0"
@@ -414,6 +497,7 @@ babel-generator@^6.18.0, babel-generator@^6.26.0:
 babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  integrity sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=
   dependencies:
     babel-helper-explode-assignable-expression "^6.24.1"
     babel-runtime "^6.22.0"
@@ -422,6 +506,7 @@ babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
 babel-helper-builder-react-jsx@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz#39ff8313b75c8b65dceff1f31d383e0ff2a408a0"
+  integrity sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=
   dependencies:
     babel-runtime "^6.26.0"
     babel-types "^6.26.0"
@@ -430,6 +515,7 @@ babel-helper-builder-react-jsx@^6.24.1:
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
+  integrity sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=
   dependencies:
     babel-helper-hoist-variables "^6.24.1"
     babel-runtime "^6.22.0"
@@ -439,6 +525,7 @@ babel-helper-call-delegate@^6.24.1:
 babel-helper-define-map@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz#a5f56dab41a25f97ecb498c7ebaca9819f95be5f"
+  integrity sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=
   dependencies:
     babel-helper-function-name "^6.24.1"
     babel-runtime "^6.26.0"
@@ -448,6 +535,7 @@ babel-helper-define-map@^6.24.1:
 babel-helper-explode-assignable-expression@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  integrity sha1-8luCz33BBDPFX3BZLVdGQArCLKo=
   dependencies:
     babel-runtime "^6.22.0"
     babel-traverse "^6.24.1"
@@ -456,6 +544,7 @@ babel-helper-explode-assignable-expression@^6.24.1:
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
+  integrity sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=
   dependencies:
     babel-helper-get-function-arity "^6.24.1"
     babel-runtime "^6.22.0"
@@ -466,6 +555,7 @@ babel-helper-function-name@^6.24.1:
 babel-helper-get-function-arity@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz#8f7782aa93407c41d3aa50908f89b031b1b6853d"
+  integrity sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
@@ -473,6 +563,7 @@ babel-helper-get-function-arity@^6.24.1:
 babel-helper-hoist-variables@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz#1ecb27689c9d25513eadbc9914a73f5408be7a76"
+  integrity sha1-HssnaJydJVE+rbyZFKc/VAi+enY=
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
@@ -480,6 +571,7 @@ babel-helper-hoist-variables@^6.24.1:
 babel-helper-optimise-call-expression@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz#f7a13427ba9f73f8f4fa993c54a97882d1244257"
+  integrity sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
@@ -487,6 +579,7 @@ babel-helper-optimise-call-expression@^6.24.1:
 babel-helper-regex@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz#325c59f902f82f24b74faceed0363954f6495e72"
+  integrity sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=
   dependencies:
     babel-runtime "^6.26.0"
     babel-types "^6.26.0"
@@ -495,6 +588,7 @@ babel-helper-regex@^6.24.1:
 babel-helper-remap-async-to-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  integrity sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=
   dependencies:
     babel-helper-function-name "^6.24.1"
     babel-runtime "^6.22.0"
@@ -505,6 +599,7 @@ babel-helper-remap-async-to-generator@^6.24.1:
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
+  integrity sha1-v22/5Dk40XNpohPKiov3S2qQqxo=
   dependencies:
     babel-helper-optimise-call-expression "^6.24.1"
     babel-messages "^6.23.0"
@@ -516,6 +611,7 @@ babel-helper-replace-supers@^6.24.1:
 babel-helpers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
+  integrity sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
@@ -523,6 +619,7 @@ babel-helpers@^6.24.1:
 babel-jest@20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-20.0.3.tgz#e4a03b13dc10389e140fc645d09ffc4ced301671"
+  integrity sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=
   dependencies:
     babel-core "^6.0.0"
     babel-plugin-istanbul "^4.0.0"
@@ -531,6 +628,7 @@ babel-jest@20.0.3:
 babel-jest@^22.0.6, babel-jest@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.4.tgz#977259240420e227444ebe49e226a61e49ea659d"
+  integrity sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==
   dependencies:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.4.4"
@@ -538,24 +636,28 @@ babel-jest@^22.0.6, babel-jest@^22.4.4:
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
+  integrity sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-external-helpers@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
+  integrity sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.5:
   version "4.1.6"
-  resolved "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  integrity sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.13.0"
     find-up "^2.1.0"
@@ -565,14 +667,17 @@ babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.5:
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
+  integrity sha1-r+3IU70/jcNUjqZx++adA8wsF2c=
 
 babel-plugin-jest-hoist@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz#b9851906eab34c7bf6f8c895a2b08bea1a844c0b"
+  integrity sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==
 
 babel-plugin-lodash@^3.2.11:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
+  integrity sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0-beta.49"
     "@babel/types" "^7.0.0-beta.49"
@@ -582,31 +687,38 @@ babel-plugin-lodash@^3.2.11:
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+  integrity sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+  integrity sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=
 
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+  integrity sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=
 
 babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+  integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
 
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+  integrity sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=
 
 babel-plugin-transform-async-to-generator@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  integrity sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=
   dependencies:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
@@ -615,18 +727,21 @@ babel-plugin-transform-async-to-generator@^6.22.0:
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
+  integrity sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz#bbc51b49f964d70cb8d8e0b94e820246ce3a6141"
+  integrity sha1-u8UbSflk1wy42OC5ToICRs46YUE=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-block-scoping@^6.23.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
+  integrity sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=
   dependencies:
     babel-runtime "^6.26.0"
     babel-template "^6.26.0"
@@ -637,6 +752,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
 babel-plugin-transform-es2015-classes@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
+  integrity sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=
   dependencies:
     babel-helper-define-map "^6.24.1"
     babel-helper-function-name "^6.24.1"
@@ -651,6 +767,7 @@ babel-plugin-transform-es2015-classes@^6.23.0:
 babel-plugin-transform-es2015-computed-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
+  integrity sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
@@ -658,12 +775,14 @@ babel-plugin-transform-es2015-computed-properties@^6.22.0:
 babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
+  integrity sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
+  integrity sha1-c+s9MQypaePvnskcU3QabxV2Qj4=
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
@@ -671,12 +790,14 @@ babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
 babel-plugin-transform-es2015-for-of@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
+  integrity sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-function-name@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
+  integrity sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=
   dependencies:
     babel-helper-function-name "^6.24.1"
     babel-runtime "^6.22.0"
@@ -685,12 +806,14 @@ babel-plugin-transform-es2015-function-name@^6.22.0:
 babel-plugin-transform-es2015-literals@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz#4f54a02d6cd66cf915280019a31d31925377ca2e"
+  integrity sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
+  integrity sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=
   dependencies:
     babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
     babel-runtime "^6.22.0"
@@ -699,6 +822,7 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
 babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.26.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
+  integrity sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==
   dependencies:
     babel-plugin-transform-strict-mode "^6.24.1"
     babel-runtime "^6.26.0"
@@ -708,6 +832,7 @@ babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-e
 babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
+  integrity sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=
   dependencies:
     babel-helper-hoist-variables "^6.24.1"
     babel-runtime "^6.22.0"
@@ -716,6 +841,7 @@ babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
 babel-plugin-transform-es2015-modules-umd@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
+  integrity sha1-rJl+YoXNGO1hdq22B9YCNErThGg=
   dependencies:
     babel-plugin-transform-es2015-modules-amd "^6.24.1"
     babel-runtime "^6.22.0"
@@ -724,6 +850,7 @@ babel-plugin-transform-es2015-modules-umd@^6.23.0:
 babel-plugin-transform-es2015-object-super@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
+  integrity sha1-JM72muIcuDp/hgPa0CH1cusnj40=
   dependencies:
     babel-helper-replace-supers "^6.24.1"
     babel-runtime "^6.22.0"
@@ -731,6 +858,7 @@ babel-plugin-transform-es2015-object-super@^6.22.0:
 babel-plugin-transform-es2015-parameters@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
+  integrity sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=
   dependencies:
     babel-helper-call-delegate "^6.24.1"
     babel-helper-get-function-arity "^6.24.1"
@@ -742,6 +870,7 @@ babel-plugin-transform-es2015-parameters@^6.23.0:
 babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
+  integrity sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
@@ -749,12 +878,14 @@ babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
 babel-plugin-transform-es2015-spread@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
+  integrity sha1-1taKmfia7cRTbIGlQujdnxdG+NE=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-sticky-regex@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
+  integrity sha1-AMHNsaynERLN8M9hJsLta0V8zbw=
   dependencies:
     babel-helper-regex "^6.24.1"
     babel-runtime "^6.22.0"
@@ -763,18 +894,21 @@ babel-plugin-transform-es2015-sticky-regex@^6.22.0:
 babel-plugin-transform-es2015-template-literals@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
+  integrity sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
+  integrity sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-unicode-regex@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
+  integrity sha1-04sS9C6nMj9yk4fxinxa4frrNek=
   dependencies:
     babel-helper-regex "^6.24.1"
     babel-runtime "^6.22.0"
@@ -783,6 +917,7 @@ babel-plugin-transform-es2015-unicode-regex@^6.22.0:
 babel-plugin-transform-exponentiation-operator@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  integrity sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=
   dependencies:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
@@ -791,6 +926,7 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
 babel-plugin-transform-flow-strip-types@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
+  integrity sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
@@ -798,12 +934,14 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
 babel-plugin-transform-inline-environment-variables@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-6.8.0.tgz#fc91dd08127dc6c2abdfd1721b11e9602a69ba10"
+  integrity sha1-/JHdCBJ9xsKr39FyGxHpYCppuhA=
   dependencies:
     babel-runtime "^6.0.0"
 
 babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.26.0"
@@ -811,12 +949,14 @@ babel-plugin-transform-object-rest-spread@^6.26.0:
 babel-plugin-transform-react-display-name@^6.23.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
+  integrity sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-react-jsx-self@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"
+  integrity sha1-322AqdomEqEh5t3XVYvL7PBuY24=
   dependencies:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
@@ -824,6 +964,7 @@ babel-plugin-transform-react-jsx-self@^6.22.0:
 babel-plugin-transform-react-jsx-source@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
+  integrity sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=
   dependencies:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
@@ -831,6 +972,7 @@ babel-plugin-transform-react-jsx-source@^6.22.0:
 babel-plugin-transform-react-jsx@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz#840a028e7df460dfc3a2d29f0c0d91f6376e66a3"
+  integrity sha1-hAoCjn30YN/DotKfDA2R9jduZqM=
   dependencies:
     babel-helper-builder-react-jsx "^6.24.1"
     babel-plugin-syntax-jsx "^6.8.0"
@@ -839,18 +981,21 @@ babel-plugin-transform-react-jsx@^6.24.1:
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
+  integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=
   dependencies:
     regenerator-transform "^0.10.0"
 
 babel-plugin-transform-runtime@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
   dependencies:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
+  integrity sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
@@ -858,6 +1003,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
 babel-polyfill@6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  integrity sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=
   dependencies:
     babel-runtime "^6.22.0"
     core-js "^2.4.0"
@@ -866,6 +1012,7 @@ babel-polyfill@6.23.0:
 babel-polyfill@^6.16.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
   dependencies:
     babel-runtime "^6.26.0"
     core-js "^2.5.0"
@@ -874,6 +1021,7 @@ babel-polyfill@^6.16.0, babel-polyfill@^6.26.0:
 babel-preset-env@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
+  integrity sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==
   dependencies:
     babel-plugin-check-es2015-constants "^6.22.0"
     babel-plugin-syntax-trailing-function-commas "^6.22.0"
@@ -909,18 +1057,21 @@ babel-preset-env@^1.7.0:
 babel-preset-flow@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
+  integrity sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
 
 babel-preset-jest@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz#cbacaadecb5d689ca1e1de1360ebfc66862c178a"
+  integrity sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=
   dependencies:
     babel-plugin-jest-hoist "^20.0.3"
 
 babel-preset-jest@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz#ec9fbd8bcd7dfd24b8b5320e0e688013235b7c39"
+  integrity sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==
   dependencies:
     babel-plugin-jest-hoist "^22.4.4"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
@@ -928,6 +1079,7 @@ babel-preset-jest@^22.4.4:
 babel-preset-react@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
+  integrity sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=
   dependencies:
     babel-plugin-syntax-jsx "^6.3.13"
     babel-plugin-transform-react-display-name "^6.23.0"
@@ -939,6 +1091,7 @@ babel-preset-react@^6.23.0:
 babel-register@^6.23.0, babel-register@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  integrity sha1-btAhFz4vy0htestFxgCahW9kcHE=
   dependencies:
     babel-core "^6.26.0"
     babel-runtime "^6.26.0"
@@ -951,6 +1104,7 @@ babel-register@^6.23.0, babel-register@^6.26.0:
 babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
@@ -958,6 +1112,7 @@ babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtim
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
   dependencies:
     babel-runtime "^6.26.0"
     babel-traverse "^6.26.0"
@@ -968,6 +1123,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
 babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
   dependencies:
     babel-code-frame "^6.26.0"
     babel-messages "^6.23.0"
@@ -982,6 +1138,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-tr
 babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
   dependencies:
     babel-runtime "^6.26.0"
     esutils "^2.0.2"
@@ -991,18 +1148,22 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
 babylon@^6.17.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
   dependencies:
     cache-base "^1.0.1"
     class-utils "^0.3.5"
@@ -1015,24 +1176,29 @@ base@^0.11.1:
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
 
 binary-extensions@^1.0.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.0.tgz#9523e001306a32444b907423f1de2164222f6ab1"
+  integrity sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==
 
 bluebird@^2.9.33:
   version "2.11.0"
-  resolved "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+  integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1040,6 +1206,7 @@ brace-expansion@^1.1.7:
 braces@^1.8.0, braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
+  integrity sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=
   dependencies:
     expand-range "^1.8.1"
     preserve "^0.2.0"
@@ -1048,6 +1215,7 @@ braces@^1.8.0, braces@^1.8.2:
 braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
   dependencies:
     arr-flatten "^1.1.0"
     array-unique "^0.3.2"
@@ -1063,20 +1231,24 @@ braces@^2.3.1:
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browser-process-hrtime@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
+  integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
 
 browser-resolve@^1.11.2:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
   dependencies:
     resolve "1.1.7"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
-  resolved "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
   dependencies:
     buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
@@ -1088,6 +1260,7 @@ browserify-aes@^1.0.0, browserify-aes@^1.0.4:
 browserify-cipher@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
+  integrity sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
   dependencies:
     browserify-aes "^1.0.4"
     browserify-des "^1.0.0"
@@ -1096,6 +1269,7 @@ browserify-cipher@^1.0.0:
 browserify-des@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
+  integrity sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
   dependencies:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
@@ -1104,7 +1278,8 @@ browserify-des@^1.0.0:
 
 browserify-rsa@^4.0.0:
   version "4.0.1"
-  resolved "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
+  integrity sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
   dependencies:
     bn.js "^4.1.0"
     randombytes "^2.0.1"
@@ -1112,6 +1287,7 @@ browserify-rsa@^4.0.0:
 browserify-sign@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.0.4.tgz#aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298"
+  integrity sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=
   dependencies:
     bn.js "^4.1.1"
     browserify-rsa "^4.0.0"
@@ -1124,12 +1300,14 @@ browserify-sign@^4.0.0:
 browserify-zlib@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
+  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   dependencies:
     pako "~1.0.5"
 
 browserslist@^3.2.6:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
   dependencies:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
@@ -1137,36 +1315,38 @@ browserslist@^3.2.6:
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
+  integrity sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=
   dependencies:
     node-int64 "^0.4.0"
 
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+  integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^4.3.0:
   version "4.9.1"
-  resolved "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+  integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
 bundlesize@^0.15.2:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/bundlesize/-/bundlesize-0.15.3.tgz#5cf7a48c11fd2835cfc9112e24429bb47c086ca8"
+  integrity sha512-CqLtaDKQFZVh9l53Py67lJOLOT//aNrmF9xT1v5cS080bbqyhOdTX5+LuoVI8LOKa351fUikGcxsQDYWQXfizg==
   dependencies:
     axios "^0.16.2"
     bytes "^3.0.0"
@@ -1182,14 +1362,17 @@ bundlesize@^0.15.2:
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
+  integrity sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=
 
 bytes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
   dependencies:
     collection-visit "^1.0.0"
     component-emitter "^1.2.1"
@@ -1204,26 +1387,31 @@ cache-base@^1.0.1:
 cachedir@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-1.3.0.tgz#5e01928bf2d95b5edd94b0942188246740e0dbc4"
+  integrity sha512-O1ji32oyON9laVPJL1IZ5bmwd2cB46VfpxkDequezH+15FDzzVddEyrGEeX4WusDSqKxdyFdDQDEG1yo1GoWkg==
   dependencies:
     os-homedir "^1.0.1"
 
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  integrity sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=
   dependencies:
     callsites "^0.2.0"
 
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+  integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
 
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
+  integrity sha1-MIvur/3ygRkFHvodkyITyRuPkuc=
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
@@ -1231,6 +1419,7 @@ camelcase-keys@^2.0.0:
 camelcase-keys@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
+  integrity sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=
   dependencies:
     camelcase "^4.1.0"
     map-obj "^2.0.0"
@@ -1239,44 +1428,39 @@ camelcase-keys@^4.0.0:
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
+  integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
 caniuse-lite@^1.0.30000844:
-  version "1.0.30000885"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz#e889e9f8e7e50e769f2a49634c932b8aee622984"
+  version "1.0.30000939"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz#b9ab7ac9e861bf78840b80c5dfbc471a5cd7e679"
+  integrity sha512-oXB23ImDJOgQpGjRv1tCtzAvJr4/OvrHi5SO2vUgB0g0xpdZZoA/BxfImiWfdwoYdUTtQrPsXsvYU/dmCSM8gg==
 
 capture-exit@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
+  integrity sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=
   dependencies:
     rsvp "^3.3.3"
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
+  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-
-chai-subset@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
-
-chai@^3.0.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
-  dependencies:
-    assertion-error "^1.0.1"
-    deep-eql "^0.1.3"
-    type-detect "^1.0.0"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
-  resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
   dependencies:
     ansi-styles "^2.2.1"
     escape-string-regexp "^1.0.2"
@@ -1287,14 +1471,16 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
 chalk@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  integrity sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -1303,14 +1489,17 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+  integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
+  integrity sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=
   dependencies:
     anymatch "^1.3.0"
     async-each "^1.0.0"
@@ -1323,21 +1512,25 @@ chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chownr@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+chownr@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
 ci-env@^1.4.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/ci-env/-/ci-env-1.6.1.tgz#3e3ef4fc528a2825397f912cfa30cde17ec364cc"
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ci-env/-/ci-env-1.7.0.tgz#55cc9f8ff7bb4380de298cbed3ae27c35dcdfd8e"
+  integrity sha512-ifHfV5JmACoTnoPxwjKjUUAekL1UCKZ9EU27GaaSkLVopkV3H1w0eYIpY+aAiX31SVEtTrZFMS94EFETSj0vIA==
 
 ci-info@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.5.1.tgz#17e8eb5de6f8b2b6038f0cbb714d410bfa9f3030"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
@@ -1345,10 +1538,12 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+  integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
 
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
   dependencies:
     arr-union "^3.1.0"
     define-property "^0.2.5"
@@ -1358,22 +1553,26 @@ class-utils@^0.3.5:
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  integrity sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
   dependencies:
     restore-cursor "^1.0.1"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
 
 cli-spinners@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+  integrity sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=
 
 cli-truncate@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
   dependencies:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
@@ -1381,10 +1580,12 @@ cli-truncate@^0.2.1:
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+  integrity sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
@@ -1393,6 +1594,7 @@ cliui@^3.2.0:
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
@@ -1401,10 +1603,12 @@ cliui@^4.0.0:
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 cmd-shim@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
+  integrity sha1-b8vamUg6j9FdfTChlspp1oii79s=
   dependencies:
     graceful-fs "^4.1.2"
     mkdirp "~0.5.0"
@@ -1412,14 +1616,17 @@ cmd-shim@^2.0.2:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  integrity sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
@@ -1427,41 +1634,49 @@ collection-visit@^1.0.0:
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
+  integrity sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=
   dependencies:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@1.0.6, combined-stream@~1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
 
 command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
+  integrity sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=
 
 commander@^2.11.0, commander@^2.9.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
 commitizen@^2.9.6:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/commitizen/-/commitizen-2.10.1.tgz#8c395def34a895f4e94952c2efc3c9eb4c3683bd"
+  integrity sha1-jDld7zSolfTpSVLC78PJ60w2g70=
   dependencies:
     cachedir "^1.1.0"
     chalk "1.1.3"
@@ -1483,10 +1698,12 @@ commitizen@^2.9.6:
 common-tags@^1.3.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
+  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
 
 compare-func@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/compare-func/-/compare-func-1.3.2.tgz#99dd0ba457e1f9bc722b12c08ec33eeab31fa648"
+  integrity sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=
   dependencies:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
@@ -1494,14 +1711,17 @@ compare-func@^1.3.1:
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 concat-stream@^1.4.10, concat-stream@^1.4.7, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
   dependencies:
     buffer-from "^1.0.0"
     inherits "^2.0.3"
@@ -1511,20 +1731,24 @@ concat-stream@^1.4.10, concat-stream@^1.4.7, concat-stream@^1.5.2:
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
+  integrity sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=
   dependencies:
     date-now "^0.1.4"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+  integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
 conventional-changelog-angular@^1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz#b27f2b315c16d0a1f23eb181309d0e6a4698ea0f"
+  integrity sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==
   dependencies:
     compare-func "^1.3.1"
     q "^1.5.1"
@@ -1532,12 +1756,14 @@ conventional-changelog-angular@^1.6.6:
 conventional-changelog-atom@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz#8037693455990e3256f297320a45fa47ee553a14"
+  integrity sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==
   dependencies:
     q "^1.5.1"
 
 conventional-changelog-cli@^1.3.13:
   version "1.3.22"
   resolved "https://registry.yarnpkg.com/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz#13570fe1728f56f013ff7a88878ff49d5162a405"
+  integrity sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==
   dependencies:
     add-stream "^1.0.0"
     conventional-changelog "^1.1.24"
@@ -1548,12 +1774,14 @@ conventional-changelog-cli@^1.3.13:
 conventional-changelog-codemirror@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz#a1982c8291f4ee4d6f2f62817c6b2ecd2c4b7b47"
+  integrity sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==
   dependencies:
     q "^1.5.1"
 
 conventional-changelog-core@^2.0.11:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz#19b5fbd55a9697773ed6661f4e32030ed7e30287"
+  integrity sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==
   dependencies:
     conventional-changelog-writer "^3.0.9"
     conventional-commits-parser "^2.1.7"
@@ -1572,36 +1800,42 @@ conventional-changelog-core@^2.0.11:
 conventional-changelog-ember@^0.3.12:
   version "0.3.12"
   resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz#b7d31851756d0fcb49b031dffeb6afa93b202400"
+  integrity sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==
   dependencies:
     q "^1.5.1"
 
 conventional-changelog-eslint@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz#b13cc7e4b472c819450ede031ff1a75c0e3d07d3"
+  integrity sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==
   dependencies:
     q "^1.5.1"
 
 conventional-changelog-express@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz#4a6295cb11785059fb09202180d0e59c358b9c2c"
+  integrity sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==
   dependencies:
     q "^1.5.1"
 
 conventional-changelog-jquery@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz#0208397162e3846986e71273b6c79c5b5f80f510"
+  integrity sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=
   dependencies:
     q "^1.4.1"
 
 conventional-changelog-jscs@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz#0479eb443cc7d72c58bf0bcf0ef1d444a92f0e5c"
+  integrity sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=
   dependencies:
     q "^1.4.1"
 
 conventional-changelog-jshint@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz#9051c1ac0767abaf62a31f74d2fe8790e8acc6c8"
+  integrity sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==
   dependencies:
     compare-func "^1.3.1"
     q "^1.5.1"
@@ -1609,10 +1843,12 @@ conventional-changelog-jshint@^0.3.8:
 conventional-changelog-preset-loader@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz#40bb0f142cd27d16839ec6c74ee8db418099b373"
+  integrity sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==
 
 conventional-changelog-writer@^3.0.9:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz#4aecdfef33ff2a53bb0cf3b8071ce21f0e994634"
+  integrity sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==
   dependencies:
     compare-func "^1.3.1"
     conventional-commits-filter "^1.1.6"
@@ -1628,6 +1864,7 @@ conventional-changelog-writer@^3.0.9:
 conventional-changelog@^1.1.24:
   version "1.1.24"
   resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-1.1.24.tgz#3d94c29c960f5261c002678315b756cdd3d7d1f0"
+  integrity sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==
   dependencies:
     conventional-changelog-angular "^1.6.6"
     conventional-changelog-atom "^0.2.8"
@@ -1644,10 +1881,12 @@ conventional-changelog@^1.1.24:
 conventional-commit-types@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz#5db95739d6c212acbe7b6f656a11b940baa68946"
+  integrity sha1-XblXOdbCEqy+e29lahG5QLqmiUY=
 
 conventional-commits-filter@^1.1.1, conventional-commits-filter@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz#4389cd8e58fe89750c0b5fb58f1d7f0cc8ad3831"
+  integrity sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==
   dependencies:
     is-subset "^0.1.1"
     modify-values "^1.0.0"
@@ -1655,6 +1894,7 @@ conventional-commits-filter@^1.1.1, conventional-commits-filter@^1.1.6:
 conventional-commits-parser@^2.1.1, conventional-commits-parser@^2.1.7:
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz#eca45ed6140d72ba9722ee4132674d639e644e8e"
+  integrity sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.0"
@@ -1667,6 +1907,7 @@ conventional-commits-parser@^2.1.1, conventional-commits-parser@^2.1.7:
 conventional-recommended-bump@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz#1b7137efb5091f99fe009e2fe9ddb7cc490e9375"
+  integrity sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==
   dependencies:
     concat-stream "^1.4.10"
     conventional-commits-filter "^1.1.1"
@@ -1679,24 +1920,29 @@ conventional-recommended-bump@^1.2.1:
 convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
   dependencies:
     safe-buffer "~5.1.1"
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 cosmiconfig@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  integrity sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=
   dependencies:
     graceful-fs "^4.1.2"
     js-yaml "^3.4.3"
@@ -1708,19 +1954,21 @@ cosmiconfig@^1.1.0:
     require-from-string "^1.1.0"
 
 coveralls@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.2.tgz#f5a0bcd90ca4e64e088b710fa8dda640aea4884f"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.3.tgz#83b1c64aea1c6afa69beaf50b55ac1bc4d13e2b8"
+  integrity sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==
   dependencies:
     growl "~> 1.10.0"
     js-yaml "^3.11.0"
     lcov-parse "^0.0.10"
     log-driver "^1.2.7"
     minimist "^1.2.0"
-    request "^2.85.0"
+    request "^2.86.0"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
+  integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
@@ -1728,12 +1976,14 @@ create-ecdh@^4.0.0:
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
   dependencies:
     capture-stack-trace "^1.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
-  resolved "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
@@ -1743,7 +1993,8 @@ create-hash@^1.1.0, create-hash@^1.1.2:
 
 create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
   version "1.1.7"
-  resolved "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
   dependencies:
     cipher-base "^1.0.3"
     create-hash "^1.1.0"
@@ -1755,6 +2006,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
 cross-env@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-3.2.4.tgz#9e0585f277864ed421ce756f81a980ff0d698aba"
+  integrity sha1-ngWF8neGTtQhznVvgamA/w1piro=
   dependencies:
     cross-spawn "^5.1.0"
     is-windows "^1.0.0"
@@ -1762,6 +2014,7 @@ cross-env@^3.2.3:
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
@@ -1770,6 +2023,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
   dependencies:
     browserify-cipher "^1.0.0"
     browserify-sign "^4.0.0"
@@ -1784,24 +2038,28 @@ crypto-browserify@^3.11.0:
     randomfill "^1.0.3"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.6.tgz#f85206cee04efa841f3c5982a74ba96ab20d65ad"
+  integrity sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==
 
 cssstyle@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.2.1.tgz#3aceb2759eaf514ac1a21628d723d6043a819495"
+  integrity sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==
   dependencies:
     cssom "0.3.x"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
+  integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
   dependencies:
     array-find-index "^1.0.1"
 
 cz-conventional-changelog@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/cz-conventional-changelog/-/cz-conventional-changelog-2.0.0.tgz#55a979afdfe95e7024879d2a0f5924630170b533"
+  integrity sha1-Val5r9/pXnAkh50qD1kkYwFwtTM=
   dependencies:
     conventional-commit-types "^2.0.0"
     lodash.map "^4.5.1"
@@ -1813,62 +2071,66 @@ cz-conventional-changelog@2.0.0:
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  integrity sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
   dependencies:
     es5-ext "^0.10.9"
 
 dargs@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
+  integrity sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=
   dependencies:
     number-is-nan "^1.0.0"
 
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
 
 data-urls@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.1.tgz#d416ac3896918f29ca84d81085bc3705834da579"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
+  integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
   dependencies:
     abab "^2.0.0"
-    whatwg-mimetype "^2.1.0"
+    whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
 date-fns@^1.27.2:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+  integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
-
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  dependencies:
-    ms "2.0.0"
+  integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
 debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.5.tgz#c2418fbfd7a29f4d4f70ff4cea604d4b64c46407"
+debug@^3.1.0, debug@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
 decamelize-keys@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
+  integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
   dependencies:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
@@ -1876,93 +2138,90 @@ decamelize-keys@^1.0.0:
 decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
 dedent@0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.6.0.tgz#0e6da8f0ce52838ef5cec5c8f9396b0c1b64a3cb"
+  integrity sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=
 
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
-
-deep-eql@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
-  dependencies:
-    type-detect "0.1.1"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+  integrity sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=
   dependencies:
     strip-bom "^2.0.0"
 
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
 
 define-properties@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  integrity sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
   dependencies:
     is-descriptor "^0.1.0"
 
 define-property@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
   dependencies:
     is-descriptor "^1.0.0"
 
 define-property@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-del@^2.0.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
-  dependencies:
-    globby "^5.0.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    rimraf "^2.2.8"
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
+  integrity sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
@@ -1970,34 +2229,41 @@ des.js@^1.0.0:
 detect-file@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"
+  integrity sha1-STXe39lIhkjgBrASlWbpOGcR6mM=
   dependencies:
     fs-exists-sync "^0.1.0"
 
 detect-indent@4.0.0, detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
 
 detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
+  integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
-  resolved "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
+  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
+  integrity sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
   dependencies:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
@@ -2006,55 +2272,66 @@ diffie-hellman@^5.0.0:
 doctrine@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
 
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+  integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
 
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
+  integrity sha1-G3CK8JSknJoOfbyteQq6U52sEXc=
   dependencies:
     is-obj "^1.0.0"
 
 dotdir-regex@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dotdir-regex/-/dotdir-regex-0.1.0.tgz#d45df4c8863be6f5593d716914381767e938c0b6"
+  integrity sha1-1F30yIY75vVZPXFpFDgXZ+k4wLY=
 
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
 duplexer@^0.1.1:
   version "0.1.1"
-  resolved "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.47:
-  version "1.3.66"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.66.tgz#1410d8f8768a14dcd09d96222990f43c969af270"
+  version "1.3.113"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
+  integrity sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
 elliptic@^6.0.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
+  integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -2067,40 +2344,47 @@ elliptic@^6.0.0:
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
   dependencies:
     iconv-lite "~0.4.13"
 
 ends-with@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ends-with/-/ends-with-0.2.0.tgz#2f9da98d57a50cfda4571ce4339000500f4e6b8a"
+  integrity sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o=
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.5.1:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
   dependencies:
-    es-to-primitive "^1.1.1"
+    es-to-primitive "^1.2.0"
     function-bind "^1.1.1"
-    has "^1.0.1"
-    is-callable "^1.1.3"
+    has "^1.0.3"
+    is-callable "^1.1.4"
     is-regex "^1.0.4"
+    object-keys "^1.0.12"
 
-es-to-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
   dependencies:
-    is-callable "^1.1.1"
+    is-callable "^1.1.4"
     is-date-object "^1.0.1"
-    is-symbol "^1.0.1"
+    is-symbol "^1.0.2"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.46"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.46.tgz#efd99f67c5a7ec789baa3daa7f79870388f7f572"
+  version "0.10.48"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.48.tgz#9a0b31eeded39e64453bcedf6f9d50bbbfb43850"
+  integrity sha512-CdRvPlX/24Mj5L4NVxTs4804sxiS2CjVprgCmrgoDkdmjdY4D+ySHa7K3jJf8R40dFg0tIm3z/dk326LrnuSGw==
   dependencies:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
@@ -2109,6 +2393,7 @@ es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
 es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
   dependencies:
     d "1"
     es5-ext "^0.10.35"
@@ -2117,6 +2402,7 @@ es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
 es6-map@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  integrity sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=
   dependencies:
     d "1"
     es5-ext "~0.10.14"
@@ -2128,6 +2414,7 @@ es6-map@^0.1.3:
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  integrity sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=
   dependencies:
     d "1"
     es5-ext "~0.10.14"
@@ -2138,6 +2425,7 @@ es6-set@~0.1.5:
 es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  integrity sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
   dependencies:
     d "1"
     es5-ext "~0.10.14"
@@ -2145,6 +2433,7 @@ es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
 es6-weak-map@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  integrity sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=
   dependencies:
     d "1"
     es5-ext "^0.10.14"
@@ -2154,10 +2443,12 @@ es6-weak-map@^2.0.1:
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escodegen@^1.9.1:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.1.tgz#c485ff8d6b4cdb89e27f4a856e91f118401ca510"
+  integrity sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
@@ -2169,6 +2460,7 @@ escodegen@^1.9.1:
 escope@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+  integrity sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=
   dependencies:
     es6-map "^0.1.3"
     es6-weak-map "^2.0.1"
@@ -2178,16 +2470,19 @@ escope@^3.6.0:
 eslint-config-idiomatic@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-idiomatic/-/eslint-config-idiomatic-3.1.0.tgz#66de8313cad5b311d18950a40048678e629857e4"
+  integrity sha1-Zt6DE8rVsxHRiVCkAEhnjmKYV+Q=
 
 eslint-config-prettier@^2.3.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.10.0.tgz#ec07bc1d01f87d09f61d3840d112dc8a9791e30b"
+  integrity sha512-Mhl90VLucfBuhmcWBgbUNtgBiK955iCDK1+aHAz7QfDQF6wuzWZ6JjihZ3ejJoGlJWIuko7xLqNm8BA5uenKhA==
   dependencies:
     get-stdin "^5.0.1"
 
 eslint-plugin-prettier@^2.1.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz#b4312dcf2c1d965379d7f9d5b5f8aaadc6a45904"
+  integrity sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==
   dependencies:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
@@ -2195,6 +2490,7 @@ eslint-plugin-prettier@^2.1.2:
 eslint@^3.17.1:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+  integrity sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
@@ -2235,6 +2531,7 @@ eslint@^3.17.1:
 espree@^3.4.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  integrity sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==
   dependencies:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
@@ -2242,53 +2539,64 @@ espree@^3.4.0:
 esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
   dependencies:
     estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
   dependencies:
     estraverse "^4.1.0"
 
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
 estree-walker@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
+  integrity sha1-va/oCVOD2EFNXcLs9MkXO225QS4=
 
-estree-walker@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
+estree-walker@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.0.tgz#5d865327c44a618dde5699f763891ae31f257dae"
+  integrity sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
 event-emitter@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
   dependencies:
     d "1"
     es5-ext "~0.10.14"
 
-events@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
+  integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
@@ -2296,12 +2604,14 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
 exec-sh@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
+  integrity sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==
   dependencies:
     merge "^1.2.0"
 
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -2314,6 +2624,7 @@ execa@^0.7.0:
 execa@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -2326,20 +2637,24 @@ execa@^0.8.0:
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+  integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
 
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
 expand-brackets@^0.1.1, expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
+  integrity sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=
   dependencies:
     is-posix-bracket "^0.1.0"
 
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  integrity sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
   dependencies:
     debug "^2.3.3"
     define-property "^0.2.5"
@@ -2352,18 +2667,21 @@ expand-brackets@^2.1.4:
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
+  integrity sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
   dependencies:
     fill-range "^2.1.0"
 
 expand-tilde@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
+  integrity sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=
   dependencies:
     os-homedir "^1.0.1"
 
 expect@^22.4.0:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/expect/-/expect-22.4.3.tgz#d5a29d0a0e1fb2153557caef2674d4547e914674"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.3.tgz#d5a29d0a0e1fb2153557caef2674d4547e914674"
+  integrity sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==
   dependencies:
     ansi-styles "^3.2.0"
     jest-diff "^22.4.3"
@@ -2375,18 +2693,21 @@ expect@^22.4.0:
 export-files@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/export-files/-/export-files-2.1.1.tgz#bbf64574053a09e4eb98e5f43501d572b2c3ce7f"
+  integrity sha1-u/ZFdAU6CeTrmOX0NQHVcrLDzn8=
   dependencies:
     lazy-cache "^1.0.3"
 
 extend-shallow@^2.0.0, extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
   dependencies:
     is-extendable "^0.1.0"
 
 extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
   dependencies:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
@@ -2394,10 +2715,12 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
 extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 external-editor@^1.1.0:
   version "1.1.1"
-  resolved "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
+  integrity sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=
   dependencies:
     extend "^3.0.0"
     spawn-sync "^1.0.15"
@@ -2405,15 +2728,17 @@ external-editor@^1.1.0:
 
 external-editor@^2.0.1, external-editor@^2.0.4:
   version "2.2.0"
-  resolved "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
   dependencies:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
-external-editor@^3.0.0:
+external-editor@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
   dependencies:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
@@ -2422,12 +2747,14 @@ external-editor@^3.0.0:
 extglob@^0.3.0, extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+  integrity sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=
   dependencies:
     is-extglob "^1.0.0"
 
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
   dependencies:
     array-unique "^0.3.2"
     define-property "^1.0.0"
@@ -2441,36 +2768,44 @@ extglob@^2.0.4:
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
 
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-diff@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fb-watchman@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
+  integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
 
 figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
@@ -2478,12 +2813,14 @@ figures@^1.3.5, figures@^1.7.0:
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  integrity sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
@@ -2491,10 +2828,12 @@ file-entry-cache@^2.0.0:
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+  integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
 
 fileset@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
+  integrity sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=
   dependencies:
     glob "^7.0.3"
     minimatch "^3.0.3"
@@ -2502,6 +2841,7 @@ fileset@^2.0.2:
 fill-range@^2.1.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
+  integrity sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==
   dependencies:
     is-number "^2.1.0"
     isobject "^2.0.0"
@@ -2512,6 +2852,7 @@ fill-range@^2.1.0:
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
   dependencies:
     extend-shallow "^2.0.1"
     is-number "^3.0.0"
@@ -2521,6 +2862,7 @@ fill-range@^4.0.0:
 find-node-modules@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/find-node-modules/-/find-node-modules-1.0.4.tgz#b6deb3cccb699c87037677bcede2c5f5862b2550"
+  integrity sha1-tt6zzMtpnIcDdne87eLF9YYrJVA=
   dependencies:
     findup-sync "0.4.2"
     merge "^1.2.0"
@@ -2528,10 +2870,12 @@ find-node-modules@1.0.4:
 find-root@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"
+  integrity sha1-li/yEaqyXGUg/u641ih/j26VgHo=
 
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  integrity sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
@@ -2539,12 +2883,14 @@ find-up@^1.0.0:
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
 
 findup-sync@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.2.tgz#a8117d0f73124f5a4546839579fe52d7129fb5e5"
+  integrity sha1-qBF9D3MST1pFRoOVef5S1xKfteU=
   dependencies:
     detect-file "^0.1.0"
     is-glob "^2.0.1"
@@ -2554,6 +2900,7 @@ findup-sync@0.4.2:
 findup-sync@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-1.0.0.tgz#6f7e4b57b6ee3a4037b4414eaedea3f58f71e0ec"
+  integrity sha1-b35LV7buOkA3tEFOrt6j9Y9x4Ow=
   dependencies:
     detect-file "^0.1.0"
     is-glob "^2.0.1"
@@ -2561,77 +2908,83 @@ findup-sync@^1.0.0:
     resolve-dir "^0.1.0"
 
 flat-cache@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
+  integrity sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==
   dependencies:
     circular-json "^0.3.1"
-    del "^2.0.2"
     graceful-fs "^4.1.2"
+    rimraf "~2.6.2"
     write "^0.2.1"
 
 flux-standard-action@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/flux-standard-action/-/flux-standard-action-0.6.1.tgz#6f34211b94834ea1c3cc30f4e7afad3d0fbf71a2"
+  integrity sha1-bzQhG5SDTqHDzDD056+tPQ+/caI=
   dependencies:
     lodash.isplainobject "^3.2.0"
 
 follow-redirects@1.0.0:
   version "1.0.0"
-  resolved "http://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
+  integrity sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=
   dependencies:
     debug "^2.2.0"
 
 follow-redirects@^1.2.3:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.8.tgz#1dbfe13e45ad969f813e86c00e5296f525c885a1"
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
   dependencies:
-    debug "=3.1.0"
+    debug "^3.2.6"
 
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
+  integrity sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
 for-own@^0.1.3, for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
   dependencies:
     for-in "^1.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
 form-data@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "1.0.6"
+    combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
-  dependencies:
-    samsam "~1.1"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
 
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
+  integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
 fs-extra@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
+  integrity sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
@@ -2640,14 +2993,16 @@ fs-extra@^1.0.0:
 fs-extra@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
 fs-extra@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -2656,20 +3011,24 @@ fs-extra@^7.0.0:
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
   dependencies:
     minipass "^2.2.1"
 
 fs-readdir-recursive@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
+  integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.0.0, fsevents@^1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
+  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
@@ -2677,10 +3036,12 @@ fsevents@^1.0.0, fsevents@^1.2.3:
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
   dependencies:
     aproba "^1.0.3"
     console-control-strings "^1.0.0"
@@ -2694,26 +3055,31 @@ gauge@~2.7.3:
 generate-function@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
   dependencies:
     is-property "^1.0.2"
 
 generate-object-property@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
   dependencies:
     is-property "^1.0.0"
 
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-own-enumerable-property-symbols@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
+  integrity sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==
 
 get-pkg-repo@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz#c73b489c06d80cc5536c2c853f9e05232056972d"
+  integrity sha1-xztInAbYDMVTbCyFP54FIyBWly0=
   dependencies:
     hosted-git-info "^2.1.4"
     meow "^3.3.0"
@@ -2724,22 +3090,27 @@ get-pkg-repo@^1.0.0:
 get-port@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
+  integrity sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
 
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+  integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
 get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+  integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
 
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-value@^1.1.5:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-1.3.1.tgz#8ac7ef4f20382392b2646548f9b9ad2dc6c89642"
+  integrity sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=
   dependencies:
     arr-flatten "^1.0.1"
     is-extendable "^0.1.1"
@@ -2749,16 +3120,19 @@ get-value@^1.1.5:
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+  integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
 
 git-raw-commits@^1.3.0, git-raw-commits@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-1.3.6.tgz#27c35a32a67777c1ecd412a239a6c19d71b95aff"
+  integrity sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==
   dependencies:
     dargs "^4.0.1"
     lodash.template "^4.0.2"
@@ -2769,6 +3143,7 @@ git-raw-commits@^1.3.0, git-raw-commits@^1.3.6:
 git-remote-origin-url@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz#5282659dae2107145a11126112ad3216ec5fa65f"
+  integrity sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=
   dependencies:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
@@ -2776,6 +3151,7 @@ git-remote-origin-url@^2.0.0:
 git-semver-tags@^1.3.0, git-semver-tags@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.3.6.tgz#357ea01f7280794fe0927f2806bee6414d2caba5"
+  integrity sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==
   dependencies:
     meow "^4.0.0"
     semver "^5.5.0"
@@ -2783,18 +3159,21 @@ git-semver-tags@^1.3.0, git-semver-tags@^1.3.6:
 gitconfiglocal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz#41d045f3851a5ea88f03f24ca1c6178114464b9b"
+  integrity sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=
   dependencies:
     ini "^1.3.2"
 
 github-build@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/github-build/-/github-build-1.2.0.tgz#b0bdb705ae4088218577e863c1a301030211051f"
+  integrity sha512-Iq7NialLYz5yRZDkiX8zaOWd+N3BssJJfUvG7wd8r4MeLCN88SdxEYo2esseMLpLtP4vNXhgamg1eRm7hw59qw==
   dependencies:
     axios "0.15.3"
 
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+  integrity sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=
   dependencies:
     glob-parent "^2.0.0"
     is-glob "^2.0.0"
@@ -2802,10 +3181,12 @@ glob-base@^0.3.0:
 glob-fs-dotfiles@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/glob-fs-dotfiles/-/glob-fs-dotfiles-0.1.6.tgz#b4f17b73c188418aba47cd206cf5a7226b4a8949"
+  integrity sha1-tPF7c8GIQYq6R80gbPWnImtKiUk=
 
 glob-fs-gitignore@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/glob-fs-gitignore/-/glob-fs-gitignore-0.1.6.tgz#885e6f412f859cc59756154829dbd55726cde992"
+  integrity sha1-iF5vQS+FnMWXVhVIKdvVVybN6ZI=
   dependencies:
     findup-sync "^1.0.0"
     micromatch "^2.3.11"
@@ -2814,6 +3195,7 @@ glob-fs-gitignore@^0.1.5:
 glob-fs@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/glob-fs/-/glob-fs-0.1.7.tgz#9a7ebbfc694fae9cebec5d59dace93ecfb364f26"
+  integrity sha512-f0U3u9xK8MEYtKDCnZXvZrZAy4uNp+KSA4xfaKI/NxbE6HXhqUBQ485Uwd6jQa/Q6z1yKi804WT9y53RrwuMxQ==
   dependencies:
     async "^1.3.0"
     bluebird "^2.9.33"
@@ -2845,18 +3227,21 @@ glob-fs@^0.1.7:
 glob-parent@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-1.3.0.tgz#971edd816ed5db58705b58079647a64d0aef7968"
+  integrity sha1-lx7dgW7V21hwW1gHlkemTQrveWg=
   dependencies:
     is-glob "^2.0.0"
 
 glob-parent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
+  integrity sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
   dependencies:
     is-glob "^2.0.0"
 
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
@@ -2864,6 +3249,7 @@ glob-parent@^3.1.0:
 glob@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2872,9 +3258,10 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2886,6 +3273,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
 global-modules@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
+  integrity sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=
   dependencies:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
@@ -2893,6 +3281,7 @@ global-modules@^0.2.3:
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
+  integrity sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=
   dependencies:
     homedir-polyfill "^1.0.0"
     ini "^1.3.4"
@@ -2902,21 +3291,12 @@ global-prefix@^0.1.4:
 globals@^9.14.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-
-globby@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
+  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
 globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  integrity sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
   dependencies:
     array-union "^1.0.1"
     glob "^7.0.3"
@@ -2926,7 +3306,8 @@ globby@^6.1.0:
 
 got@^6.7.1:
   version "6.7.1"
-  resolved "http://registry.npmjs.org/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
   dependencies:
     create-error-class "^3.0.0"
     duplexer3 "^0.1.4"
@@ -2941,27 +3322,32 @@ got@^6.7.1:
     url-parse-lax "^1.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 "growl@~> 1.10.0":
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+  integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 gzip-size@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.1.0.tgz#8ae096257eabe7d69c45be2b67c448124ffb517c"
+  integrity sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=
   dependencies:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
 handlebars@^4.0.2, handlebars@^4.0.3:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
+  integrity sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==
   dependencies:
     async "^2.5.0"
     optimist "^0.6.1"
@@ -2972,39 +3358,52 @@ handlebars@^4.0.2, handlebars@^4.0.3:
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
   dependencies:
-    ajv "^5.3.0"
+    ajv "^6.5.5"
     har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
 
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
 
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  integrity sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
   dependencies:
     get-value "^2.0.3"
     has-values "^0.1.4"
@@ -3013,6 +3412,7 @@ has-value@^0.3.1:
 has-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
   dependencies:
     get-value "^2.0.6"
     has-values "^1.0.0"
@@ -3021,30 +3421,35 @@ has-value@^1.0.0:
 has-values@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+  integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
 
 has-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
+has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
+  integrity sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
@@ -3052,6 +3457,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
   dependencies:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
@@ -3060,29 +3466,34 @@ hmac-drbg@^1.0.0:
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
+  integrity sha1-42w/LSyufXRqhX440Y1fMqeILbg=
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
 homedir-polyfill@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
+  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
   dependencies:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
+  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
+  integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
   dependencies:
     whatwg-encoding "^1.0.1"
 
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
   dependencies:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
@@ -3091,44 +3502,45 @@ http-signature@~1.2.0:
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+  integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
 husky@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  integrity sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==
   dependencies:
     is-ci "^1.0.10"
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-iconv-lite@0.4.23:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
 ieee754@^1.1.4:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+  integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
 
 ignore-walk@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
   dependencies:
     minimatch "^3.0.4"
 
 ignore@^3.2.0:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
+  integrity sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==
   dependencies:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
@@ -3136,24 +3548,29 @@ import-local@^1.0.0:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
   dependencies:
     repeating "^2.0.0"
 
 indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
     wrappy "1"
@@ -3161,18 +3578,22 @@ inflight@^1.0.4:
 inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 inquirer@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-1.2.3.tgz#4dec6f32f37ef7bb0b2ed3f1d1a5c3f545074918"
+  integrity sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=
   dependencies:
     ansi-escapes "^1.1.0"
     chalk "^1.0.0"
@@ -3192,6 +3613,7 @@ inquirer@1.2.3:
 inquirer@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.0.6.tgz#e04aaa9d05b7a3cb9b0f407d04375f0447190347"
+  integrity sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=
   dependencies:
     ansi-escapes "^1.1.0"
     chalk "^1.0.0"
@@ -3210,6 +3632,7 @@ inquirer@3.0.6:
 inquirer@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+  integrity sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=
   dependencies:
     ansi-escapes "^1.1.0"
     ansi-regex "^2.0.0"
@@ -3228,6 +3651,7 @@ inquirer@^0.12.0:
 inquirer@^3.2.2:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.0"
@@ -3245,40 +3669,45 @@ inquirer@^3.2.2:
     through "^2.3.6"
 
 inquirer@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
+  integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    external-editor "^3.0.0"
+    external-editor "^3.0.3"
     figures "^2.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
     mute-stream "0.0.7"
     run-async "^2.2.0"
-    rxjs "^6.1.0"
+    rxjs "^6.4.0"
     string-width "^2.1.0"
-    strip-ansi "^4.0.0"
+    strip-ansi "^5.0.0"
     through "^2.3.6"
 
 interpret@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
 invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
 
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
 is-absolute@^0.2.2:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-0.2.6.tgz#20de69f3db942ef2d87b9c2da36f172235b1b5eb"
+  integrity sha1-IN5p89uULvLYe5wto28XIjWxtes=
   dependencies:
     is-relative "^0.2.1"
     is-windows "^0.2.0"
@@ -3286,64 +3715,69 @@ is-absolute@^0.2.2:
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  integrity sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
   dependencies:
     kind-of "^3.0.2"
 
 is-accessor-descriptor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
     kind-of "^6.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
+  integrity sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=
   dependencies:
     binary-extensions "^1.0.0"
 
 is-buffer@^1.0.2, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-builtin-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
-  dependencies:
-    builtin-modules "^1.0.0"
-
-is-callable@^1.1.1, is-callable@^1.1.3:
+is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
 
 is-ci@^1.0.10:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
     ci-info "^1.5.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  integrity sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
   dependencies:
     kind-of "^3.0.2"
 
 is-data-descriptor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
 
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
   dependencies:
     is-accessor-descriptor "^0.1.6"
     is-data-descriptor "^0.1.4"
@@ -3352,6 +3786,7 @@ is-descriptor@^0.1.0:
 is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
   dependencies:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
@@ -3360,86 +3795,103 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
 is-dotdir@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-dotdir/-/is-dotdir-0.1.0.tgz#da1e5464f59fc3a83c1d822b5ace091b45fe6b31"
+  integrity sha1-2h5UZPWfw6g8HYIrWs4JG0X+azE=
   dependencies:
     dotdir-regex "^0.1.0"
 
 is-dotfile@^1.0.0, is-dotfile@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
+  integrity sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=
 
 is-equal-shallow@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+  integrity sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=
   dependencies:
     is-primitive "^2.0.0"
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
 
 is-extendable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
     is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+  integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
 
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  integrity sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=
   dependencies:
     number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
   dependencies:
     number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
+  integrity sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=
 
 is-glob@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-1.1.3.tgz#b4c64b8303d39114492a460d364ccfb0d3c0a045"
+  integrity sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU=
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
   dependencies:
     is-extglob "^1.0.0"
 
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
   dependencies:
     is-extglob "^2.1.0"
 
 is-glob@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
   dependencies:
     is-extglob "^2.1.1"
 
 is-my-ip-valid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
+  integrity sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==
 
 is-my-json-valid@^2.10.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz#8fd6e40363cd06b963fa877d444bfb5eddc62175"
+  integrity sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
@@ -3450,166 +3902,190 @@ is-my-json-valid@^2.10.0:
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  integrity sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=
   dependencies:
     kind-of "^3.0.2"
 
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
 
 is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
 is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
-  resolved "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  dependencies:
-    is-path-inside "^1.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  dependencies:
-    path-is-inside "^1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+  integrity sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=
 
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+  integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-property@^1.0.0, is-property@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
 
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-relative@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.2.1.tgz#d27f4c7d516d175fb610db84bbeef23c3bc97aa5"
+  integrity sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=
   dependencies:
     is-unc-path "^0.1.1"
 
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+  integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
 is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+  integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+  integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
 
-is-symbol@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-text-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-text-path/-/is-text-path-1.0.1.tgz#4e1aa0fb51bfbcb3e92688001397202c1775b66e"
+  integrity sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=
   dependencies:
     text-extensions "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
 is-unc-path@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-0.1.2.tgz#6ab053a72573c10250ff416a3814c35178af39b9"
+  integrity sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=
   dependencies:
     unc-path-regex "^0.1.0"
 
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
 is-windows@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.1.1.tgz#be310715431cfabccc54ab3951210fa0b6d01abe"
+  integrity sha1-vjEHFUMc+rzMVKs5USEPoLbQGr4=
 
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+  integrity sha1-3hqm1j6indJIc3tp8f+LgALSEIw=
 
 is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-1.0.2.tgz#f0f9b8ce92dd540fa0740882e3835a2e022ec78a"
+  integrity sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=
 
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
     isarray "1.0.0"
 
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 istanbul-api@^1.1.14:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.7.tgz#a86c770d2b03e11e3f778cd7aedd82d2722092aa"
+  integrity sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==
   dependencies:
     async "^2.1.4"
     fileset "^2.0.2"
@@ -3626,16 +4102,19 @@ istanbul-api@^1.1.14:
 istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#ccf7edcd0a0bb9b8f729feeb0930470f9af664f0"
+  integrity sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==
 
 istanbul-lib-hook@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz#bc6bf07f12a641fbf1c85391d0daa8f0aea6bf86"
+  integrity sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==
   dependencies:
     append-transform "^0.4.0"
 
 istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.10.2, istanbul-lib-instrument@^1.8.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz#1f55ed10ac3c47f2bdddd5307935126754d0a9ca"
+  integrity sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
@@ -3648,6 +4127,7 @@ istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.10.2, istanbul-lib-i
 istanbul-lib-report@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz#f2a657fc6282f96170aaf281eb30a458f7f4170c"
+  integrity sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==
   dependencies:
     istanbul-lib-coverage "^1.2.1"
     mkdirp "^0.5.1"
@@ -3657,6 +4137,7 @@ istanbul-lib-report@^1.1.5:
 istanbul-lib-source-maps@^1.2.1, istanbul-lib-source-maps@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz#37b9ff661580f8fca11232752ee42e08c6675d8f"
+  integrity sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==
   dependencies:
     debug "^3.1.0"
     istanbul-lib-coverage "^1.2.1"
@@ -3667,18 +4148,21 @@ istanbul-lib-source-maps@^1.2.1, istanbul-lib-source-maps@^1.2.6:
 istanbul-reports@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.5.1.tgz#97e4dbf3b515e8c484caea15d6524eebd3ff4e1a"
+  integrity sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==
   dependencies:
     handlebars "^4.0.3"
 
 jest-changed-files@^22.2.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
+  integrity sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==
   dependencies:
     throat "^4.0.0"
 
 jest-cli@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.4.4.tgz#68cd2a2aae983adb1e6638248ca21082fd6d9e90"
+  integrity sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -3718,6 +4202,7 @@ jest-cli@^22.4.4:
 jest-config@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.4.4.tgz#72a521188720597169cd8b4ff86934ef5752d86a"
+  integrity sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==
   dependencies:
     chalk "^2.0.1"
     glob "^7.1.1"
@@ -3733,7 +4218,8 @@ jest-config@^22.4.4:
 
 jest-diff@^22.4.0, jest-diff@^22.4.3:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz#e18cc3feff0aeef159d02310f2686d4065378030"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.4.3.tgz#e18cc3feff0aeef159d02310f2686d4065378030"
+  integrity sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
@@ -3743,16 +4229,19 @@ jest-diff@^22.4.0, jest-diff@^22.4.3:
 jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+  integrity sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==
 
 jest-docblock@^22.4.0, jest-docblock@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
+  integrity sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==
   dependencies:
     detect-newline "^2.1.0"
 
 jest-environment-jsdom@^22.4.1:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz#d67daa4155e33516aecdd35afd82d4abf0fa8a1e"
+  integrity sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==
   dependencies:
     jest-mock "^22.4.3"
     jest-util "^22.4.3"
@@ -3761,6 +4250,7 @@ jest-environment-jsdom@^22.4.1:
 jest-environment-node@^22.4.1:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.4.3.tgz#54c4eaa374c83dd52a9da8759be14ebe1d0b9129"
+  integrity sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==
   dependencies:
     jest-mock "^22.4.3"
     jest-util "^22.4.3"
@@ -3768,14 +4258,17 @@ jest-environment-node@^22.4.1:
 jest-get-type@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+  integrity sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==
 
 jest-get-type@^22.1.0, jest-get-type@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
+  integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
 
 jest-haste-map@^22.4.2:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz#25842fa2ba350200767ac27f658d58b9d5c2e20b"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.4.3.tgz#25842fa2ba350200767ac27f658d58b9d5c2e20b"
+  integrity sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
@@ -3788,6 +4281,7 @@ jest-haste-map@^22.4.2:
 jest-jasmine2@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz#c55f92c961a141f693f869f5f081a79a10d24e23"
+  integrity sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==
   dependencies:
     chalk "^2.0.1"
     co "^4.6.0"
@@ -3803,13 +4297,15 @@ jest-jasmine2@^22.4.4:
 
 jest-leak-detector@^22.4.0:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
+  integrity sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==
   dependencies:
     pretty-format "^22.4.3"
 
 jest-matcher-utils@^22.4.0, jest-matcher-utils@^22.4.3:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
+  integrity sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==
   dependencies:
     chalk "^2.0.1"
     jest-get-type "^22.4.3"
@@ -3818,6 +4314,7 @@ jest-matcher-utils@^22.4.0, jest-matcher-utils@^22.4.3:
 jest-message-util@^22.4.0, jest-message-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.4.3.tgz#cf3d38aafe4befddbfc455e57d65d5239e399eb7"
+  integrity sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
@@ -3828,20 +4325,24 @@ jest-message-util@^22.4.0, jest-message-util@^22.4.3:
 jest-mock@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.4.3.tgz#f63ba2f07a1511772cdc7979733397df770aabc7"
+  integrity sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==
 
 jest-regex-util@^22.1.0, jest-regex-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.4.3.tgz#a826eb191cdf22502198c5401a1fc04de9cef5af"
+  integrity sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==
 
 jest-resolve-dependencies@^22.1.0:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
+  integrity sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==
   dependencies:
     jest-regex-util "^22.4.3"
 
 jest-resolve@^22.4.2:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz#0ce9d438c8438229aa9b916968ec6b05c1abb4ea"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.4.3.tgz#0ce9d438c8438229aa9b916968ec6b05c1abb4ea"
+  integrity sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
@@ -3849,6 +4350,7 @@ jest-resolve@^22.4.2:
 jest-runner@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.4.4.tgz#dfca7b7553e0fa617e7b1291aeb7ce83e540a907"
+  integrity sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==
   dependencies:
     exit "^0.1.2"
     jest-config "^22.4.4"
@@ -3865,6 +4367,7 @@ jest-runner@^22.4.4:
 jest-runtime@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.4.4.tgz#9ba7792fc75582a5be0f79af6f8fe8adea314048"
+  integrity sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==
   dependencies:
     babel-core "^6.0.0"
     babel-jest "^22.4.4"
@@ -3890,10 +4393,12 @@ jest-runtime@^22.4.4:
 jest-serializer@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-22.4.3.tgz#a679b81a7f111e4766235f4f0c46d230ee0f7436"
+  integrity sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==
 
 jest-snapshot@^22.4.0:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz#b5c9b42846ffb9faccb76b841315ba67887362d2"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.4.3.tgz#b5c9b42846ffb9faccb76b841315ba67887362d2"
+  integrity sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==
   dependencies:
     chalk "^2.0.1"
     jest-diff "^22.4.3"
@@ -3905,6 +4410,7 @@ jest-snapshot@^22.4.0:
 jest-util@^22.4.1, jest-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.4.3.tgz#c70fec8eec487c37b10b0809dc064a7ecf6aafac"
+  integrity sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
@@ -3917,6 +4423,7 @@ jest-util@^22.4.1, jest-util@^22.4.3:
 jest-validate@^21.1.0:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
+  integrity sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==
   dependencies:
     chalk "^2.0.1"
     jest-get-type "^21.2.0"
@@ -3926,6 +4433,7 @@ jest-validate@^21.1.0:
 jest-validate@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.4.4.tgz#1dd0b616ef46c995de61810d85f57119dbbcec4d"
+  integrity sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==
   dependencies:
     chalk "^2.0.1"
     jest-config "^22.4.4"
@@ -3936,12 +4444,14 @@ jest-validate@^22.4.4:
 jest-worker@^22.2.2, jest-worker@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
+  integrity sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==
   dependencies:
     merge-stream "^1.0.1"
 
 jest@^22.0.6:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.4.tgz#ffb36c9654b339a13e10b3d4b338eb3e9d49f6eb"
+  integrity sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==
   dependencies:
     import-local "^1.0.0"
     jest-cli "^22.4.4"
@@ -3949,14 +4459,17 @@ jest@^22.0.6:
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
 js-yaml@^3.11.0, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
+  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -3964,10 +4477,12 @@ js-yaml@^3.11.0, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 jsdom@^11.5.1:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
+  integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
   dependencies:
     abab "^2.0.0"
     acorn "^5.5.3"
@@ -3999,68 +4514,83 @@ jsdom@^11.5.1:
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+  integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+  integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
 json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
   dependencies:
     jsonify "~0.0.0"
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
 json@^9.0.6:
   version "9.0.6"
   resolved "https://registry.yarnpkg.com/json/-/json-9.0.6.tgz#7972c2a5a48a42678db2730c7c2c4ee6e4e24585"
+  integrity sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=
 
 jsonfile@^2.1.0:
   version "2.4.0"
-  resolved "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
   optionalDependencies:
     graceful-fs "^4.1.6"
 
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
+  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
 
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
@@ -4070,70 +4600,84 @@ jsprim@^1.2.2:
 kind-of@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"
+  integrity sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=
 
 kind-of@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
+  integrity sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=
   dependencies:
     is-buffer "^1.0.2"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
   dependencies:
     is-buffer "^1.1.5"
 
 kind-of@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
   dependencies:
     is-buffer "^1.1.5"
 
 kind-of@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
+  integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
   optionalDependencies:
     graceful-fs "^4.1.9"
 
 lazy-cache@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.1.0.tgz#d6cd450251d415b70103765f63130a0049a03795"
+  integrity sha1-1s1FAlHUFbcBA3ZfYxMKAEmgN5U=
   dependencies:
     ansi-yellow "^0.1.1"
 
 lazy-cache@^0.2.4:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
+  integrity sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=
 
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+  integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
 
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
   dependencies:
     invert-kv "^1.0.0"
 
 lcov-parse@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+  integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
 
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
+  integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
 lerna@^2.0.0-rc.4:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.11.0.tgz#89b5681e286d388dda5bbbdbbf6b84c8094eff65"
+  integrity sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==
   dependencies:
     async "^1.5.0"
     chalk "^2.1.0"
@@ -4178,10 +4722,12 @@ lerna@^2.0.0-rc.4:
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+  integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
@@ -4189,6 +4735,7 @@ levn@^0.3.0, levn@~0.3.0:
 lint-staged@^4.0.2:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.3.0.tgz#ed0779ad9a42c0dc62bb3244e522870b41125879"
+  integrity sha512-C/Zxslg0VRbsxwmCu977iIs+QyrmW2cyRCPUV5NDFYOH/jtRFHH8ch7ua2fH0voI/nVC3Tpg7DykfgMZySliKw==
   dependencies:
     app-root-path "^2.0.0"
     chalk "^2.1.0"
@@ -4209,10 +4756,12 @@ lint-staged@^4.0.2:
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
 
 listr-update-renderer@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  integrity sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=
   dependencies:
     chalk "^1.1.3"
     cli-truncate "^0.2.1"
@@ -4226,6 +4775,7 @@ listr-update-renderer@^0.2.0:
 listr-verbose-renderer@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
+  integrity sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=
   dependencies:
     chalk "^1.1.3"
     cli-cursor "^1.0.2"
@@ -4235,6 +4785,7 @@ listr-verbose-renderer@^0.4.0:
 listr@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+  integrity sha1-a84sD1YD+klYDqF81qAMwOX6RRo=
   dependencies:
     chalk "^1.1.3"
     cli-truncate "^0.2.1"
@@ -4256,6 +4807,7 @@ listr@^0.12.0:
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+  integrity sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
   dependencies:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
@@ -4266,6 +4818,7 @@ load-json-file@^1.0.0:
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  integrity sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
   dependencies:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
@@ -4275,6 +4828,7 @@ load-json-file@^2.0.0:
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
   dependencies:
     graceful-fs "^4.1.2"
     parse-json "^4.0.0"
@@ -4284,6 +4838,7 @@ load-json-file@^4.0.0:
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
@@ -4291,22 +4846,27 @@ locate-path@^2.0.0:
 lodash._basefor@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basefor/-/lodash._basefor-3.0.3.tgz#7550b4e9218ef09fad24343b612021c79b4c20c2"
+  integrity sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
+  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
 
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+  integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
 lodash.isplainobject@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz#9a8238ae16b200432960cd7346512d0123fbf4c5"
+  integrity sha1-moI4rhayAEMpYM1zRlEtASP79MU=
   dependencies:
     lodash._basefor "^3.0.0"
     lodash.isarguments "^3.0.0"
@@ -4315,6 +4875,7 @@ lodash.isplainobject@^3.2.0:
 lodash.keysin@^3.0.0:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/lodash.keysin/-/lodash.keysin-3.0.8.tgz#22c4493ebbedb1427962a54b445b2c8a767fb47f"
+  integrity sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=
   dependencies:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
@@ -4322,14 +4883,17 @@ lodash.keysin@^3.0.0:
 lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
+  integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash.template@^4.0.2:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
+  integrity sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=
   dependencies:
     lodash._reinterpolate "~3.0.0"
     lodash.templatesettings "^4.0.0"
@@ -4337,57 +4901,63 @@ lodash.template@^4.0.2:
 lodash.templatesettings@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
+  integrity sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
 lodash@4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+  integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log-driver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
+  integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
   dependencies:
     chalk "^1.0.0"
 
 log-symbols@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
 
 log-update@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  integrity sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=
   dependencies:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "http://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
-
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
@@ -4395,10 +4965,12 @@ loud-rejection@^1.0.0:
 lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
+  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
 lru-cache@^4.0.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -4406,53 +4978,64 @@ lru-cache@^4.0.1:
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
   dependencies:
     pify "^3.0.0"
 
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+  integrity sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
   dependencies:
     tmpl "1.0.x"
 
 map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+  integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+  integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
 map-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+  integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
 
 math-random@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
+  integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
 
 md5.js@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
 
 meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
+  integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
   dependencies:
     camelcase-keys "^2.0.0"
     decamelize "^1.1.2"
@@ -4468,6 +5051,7 @@ meow@^3.3.0:
 meow@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.1.tgz#d48598f6f4b1472f35bf6317a95945ace347f975"
+  integrity sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==
   dependencies:
     camelcase-keys "^4.0.0"
     decamelize-keys "^1.0.0"
@@ -4482,16 +5066,19 @@ meow@^4.0.0:
 merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  integrity sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
   dependencies:
     readable-stream "^2.0.1"
 
 merge@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
+  integrity sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=
   dependencies:
     arr-diff "^2.0.0"
     array-unique "^0.2.1"
@@ -4507,9 +5094,10 @@ micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.4:
+micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -4525,7 +5113,7 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@jonschlinkert/micromatch#2.2.0:
+"micromatch@github:jonschlinkert/micromatch#2.2.0":
   version "2.2.0"
   resolved "https://codeload.github.com/jonschlinkert/micromatch/tar.gz/5017fd78202e04c684cc31d3c2fb1f469ea222ff"
   dependencies:
@@ -4544,77 +5132,92 @@ micromatch@jonschlinkert/micromatch#2.2.0:
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
   dependencies:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@~1.36.0:
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
+mime-db@~1.38.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
+  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.20"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
+  version "2.1.22"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
+  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
   dependencies:
-    mime-db "~1.36.0"
+    mime-db "~1.38.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimist-options@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
+  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
   dependencies:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
 minimist@0.0.8:
   version "0.0.8"
-  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
-  resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
 minimist@^0.1.0:
   version "0.1.0"
-  resolved "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+  integrity sha1-md9lelJXTCHJBXSX33QnkLK0wN4=
 
 minimist@~0.0.1:
   version "0.0.10"
-  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.2.1, minipass@^2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.4.tgz#4768d7605ed6194d6d576169b9e12ef71e9d9957"
+minipass@^2.2.1, minipass@^2.3.4:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minizlib@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+minizlib@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
 
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -4622,51 +5225,62 @@ mixin-deep@^1.2.0:
 mixin-object@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
+  integrity sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=
   dependencies:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
 mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
-  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
+  integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
 moment@^2.6.0:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+  integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
 
 mute-stream@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
+  integrity sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=
 
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 nan@^2.9.2:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
+  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -4683,10 +5297,12 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 needle@^2.2.1:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.3.tgz#c1b04da378cd634d8befe2de965dc2cfb0fd65ca"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
+  integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -4695,10 +5311,12 @@ needle@^2.2.1:
 next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 node-fetch@1.6.3:
   version "1.6.3"
-  resolved "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  integrity sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -4706,10 +5324,12 @@ node-fetch@1.6.3:
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+  integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
 node-libs-browser@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.0.tgz#c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77"
+  integrity sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==
   dependencies:
     assert "^1.1.1"
     browserify-zlib "^0.2.0"
@@ -4718,7 +5338,7 @@ node-libs-browser@^2.0.0:
     constants-browserify "^1.0.0"
     crypto-browserify "^3.11.0"
     domain-browser "^1.1.1"
-    events "^1.0.0"
+    events "^3.0.0"
     https-browserify "^1.0.0"
     os-browserify "^0.3.0"
     path-browserify "0.0.0"
@@ -4732,21 +5352,24 @@ node-libs-browser@^2.0.0:
     timers-browserify "^2.0.4"
     tty-browserify "0.0.0"
     url "^0.11.0"
-    util "^0.10.3"
+    util "^0.11.0"
     vm-browserify "0.0.4"
 
 node-notifier@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.0.tgz#7b455fdce9f7de0c63538297354f3db468426e6a"
+  integrity sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==
   dependencies:
     growly "^1.3.0"
-    semver "^5.4.1"
+    is-wsl "^1.1.0"
+    semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
 
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -4762,40 +5385,47 @@ node-pre-gyp@^0.10.0:
 noncharacters@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/noncharacters/-/noncharacters-1.1.0.tgz#af33df30fd50ed3c53cd202258f25ada90b540d2"
+  integrity sha1-rzPfMP1Q7TxTzSAiWPJa2pC1QNI=
 
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
 
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
   dependencies:
     hosted-git-info "^2.1.4"
-    is-builtin-module "^1.0.0"
+    resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
 normalize-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+  integrity sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=
 
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
 
 npm-bundled@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
+  integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
 
 npm-packlist@^1.1.6:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
+  integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -4803,18 +5433,21 @@ npm-packlist@^1.1.6:
 npm-path@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
+  integrity sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==
   dependencies:
     which "^1.2.10"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
 
 npm-which@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  integrity sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=
   dependencies:
     commander "^2.9.0"
     npm-path "^2.0.2"
@@ -4823,6 +5456,7 @@ npm-which@^3.0.1:
 npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
   dependencies:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
@@ -4832,46 +5466,55 @@ npmlog@^4.0.2, npmlog@^4.1.2:
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 nwsapi@^2.0.7:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.9.tgz#77ac0cdfdcad52b6a1151a84e73254edc33ed016"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.0.tgz#781065940aed90d9bb01ca5d0ce0fcf81c32712f"
+  integrity sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg==
 
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
   dependencies:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
 object-keys@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
 
 object-visit@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-0.1.0.tgz#b1bb6749f228ee76e0c42f3851d28a14d233ce26"
+  integrity sha1-sbtnSfIo7nbgxC84UdKKFNIzziY=
   dependencies:
     isobject "^1.0.0"
 
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.5.1"
@@ -4879,6 +5522,7 @@ object.getownpropertydescriptors@^2.0.3:
 object.omit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-1.1.0.tgz#9d17ea16778e5057deba7752c6f55f1496829e94"
+  integrity sha1-nRfqFneOUFfeundSxvVfFJaCnpQ=
   dependencies:
     for-own "^0.1.3"
     isobject "^1.0.0"
@@ -4886,6 +5530,7 @@ object.omit@^1.1.0:
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+  integrity sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
@@ -4893,28 +5538,33 @@ object.omit@^2.0.0:
 object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
 
 once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
 onetime@^1.0.0:
   version "1.1.0"
-  resolved "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+  integrity sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
 
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
 
 opencollective@1.0.3, opencollective@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/opencollective/-/opencollective-1.0.3.tgz#aee6372bc28144583690c3ca8daecfc120dd0ef1"
+  integrity sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=
   dependencies:
     babel-polyfill "6.23.0"
     chalk "1.1.3"
@@ -4926,6 +5576,7 @@ opencollective@1.0.3, opencollective@^1.0.3:
 opn@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/opn/-/opn-4.0.2.tgz#7abc22e644dff63b0a96d5ab7f2790c0f01abc95"
+  integrity sha1-erwi5kTf9jsKltWrfyeQwPAavJU=
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
@@ -4933,6 +5584,7 @@ opn@4.0.2:
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
@@ -4940,6 +5592,7 @@ optimist@^0.6.1:
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
   dependencies:
     deep-is "~0.1.3"
     fast-levenshtein "~2.0.4"
@@ -4950,7 +5603,8 @@ optionator@^0.8.1, optionator@^0.8.2:
 
 ora@^0.2.3:
   version "0.2.3"
-  resolved "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  integrity sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=
   dependencies:
     chalk "^1.1.1"
     cli-cursor "^1.0.2"
@@ -4960,14 +5614,17 @@ ora@^0.2.3:
 os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
+  integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
 os-locale@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  integrity sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==
   dependencies:
     execa "^0.7.0"
     lcid "^1.0.0"
@@ -4976,14 +5633,17 @@ os-locale@^2.0.0:
 os-shim@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
+  integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 osenv@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -4991,6 +5651,7 @@ osenv@^0.1.4:
 output-file-sync@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
+  integrity sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=
   dependencies:
     graceful-fs "^4.1.4"
     mkdirp "^0.5.1"
@@ -4999,30 +5660,36 @@ output-file-sync@^1.1.2:
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
   dependencies:
     p-try "^1.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
 
 p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
 
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 package-json@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  integrity sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=
   dependencies:
     got "^6.7.1"
     registry-auth-token "^3.0.1"
@@ -5032,26 +5699,31 @@ package-json@^4.0.1:
 pad-right@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/pad-right/-/pad-right-0.2.2.tgz#6fbc924045d244f2a2a244503060d3bfc6009774"
+  integrity sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=
   dependencies:
     repeat-string "^1.5.2"
 
 pako@~1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
+  integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
 
 parse-asn1@^5.0.0:
-  version "5.1.1"
-  resolved "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz#f6bf293818332bd0dab54efb16087724745e6ca8"
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.4.tgz#37f6628f823fbdeb2273b4d540434a22f3ef1fcc"
+  integrity sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
     create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
+    safe-buffer "^5.1.1"
 
 parse-filepath@^0.6.1:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-0.6.3.tgz#38e17a73e5e4e6776bae9506fc3ccb14bc3a2b80"
+  integrity sha1-OOF6c+Xk5ndrrpUG/DzLFLw6K4A=
   dependencies:
     is-absolute "^0.2.2"
     map-cache "^0.2.0"
@@ -5059,10 +5731,12 @@ parse-filepath@^0.6.1:
 parse-github-repo-url@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz#9e7d8bb252a6cb6ba42595060b7bf6df3dbc1f50"
+  integrity sha1-nn2LslKmy2ukJZUGC3v23z28H1A=
 
 parse-gitignore@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/parse-gitignore/-/parse-gitignore-0.2.0.tgz#98706d09f0f93ee86348b721ffee0606bc093d74"
+  integrity sha1-mHBtCfD5PuhjSLch/+4GBrwJPXQ=
   dependencies:
     ends-with "^0.2.0"
     is-glob "^2.0.0"
@@ -5071,6 +5745,7 @@ parse-gitignore@^0.2.0:
 parse-glob@^3.0.1, parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
+  integrity sha1-ssN2z7EfNVE7rdFz7wu246OIORw=
   dependencies:
     glob-base "^0.3.0"
     is-dotfile "^1.0.0"
@@ -5080,12 +5755,14 @@ parse-glob@^3.0.1, parse-glob@^3.0.4:
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
   dependencies:
     error-ex "^1.2.0"
 
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
@@ -5093,52 +5770,64 @@ parse-json@^4.0.0:
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+  integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
 
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+  integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
 
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
 path-exists@2.1.0, path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
   dependencies:
     pinkie-promise "^2.0.0"
 
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
 
 path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-parse@^1.0.5:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+  integrity sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=
   dependencies:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
@@ -5147,18 +5836,21 @@ path-type@^1.0.0:
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
   dependencies:
     pify "^2.0.0"
 
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
 
 pbkdf2@^3.0.3:
-  version "3.0.16"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.16.tgz#7404208ec6b01b62d85bf83853a8064f8d9c2a5c"
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
+  integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -5169,69 +5861,84 @@ pbkdf2@^3.0.3:
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
   dependencies:
     pinkie "^2.0.0"
 
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
 
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+  integrity sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=
 
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+  integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
 prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
+  integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+  integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
 prettier@^1.5.3:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
 pretty-format@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  integrity sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
 pretty-format@^22.4.0, pretty-format@^22.4.3:
   version "22.4.3"
-  resolved "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+  integrity sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -5239,92 +5946,112 @@ pretty-format@^22.4.0, pretty-format@^22.4.3:
 prettycli@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/prettycli/-/prettycli-1.4.3.tgz#b28ec2aad9de07ae1fd75ef294fb54cbdee07ed5"
+  integrity sha512-KLiwAXXfSWXZqGmZlnKPuGMTFp+0QbcySplL1ft9gfteT/BNsG64Xo8u2Qr9r+qnsIZWBQ66Zs8tg+8s2fmzvw==
   dependencies:
     chalk "2.1.0"
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+  integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
 
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+  integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.24:
-  version "1.1.29"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+psl@^1.1.24, psl@^1.1.28:
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
+  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
 
 public-encrypt@^4.0.0:
-  version "4.0.2"
-  resolved "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz#46eb9107206bf73489f8b85b69d91334c6610994"
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
+  integrity sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
   dependencies:
     bn.js "^4.1.0"
     browserify-rsa "^4.0.0"
     create-hash "^1.1.0"
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
+    safe-buffer "^5.1.2"
 
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 q@^1.4.1, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+  integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
 
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+  integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
 randomatic@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.1.tgz#b776efc59375984e36c537b2f51a1f0aff0da1ed"
+  integrity sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==
   dependencies:
     is-number "^4.0.0"
     kind-of "^6.0.0"
     math-random "^1.0.1"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.6.tgz#d302c522948588848a8d300c932b44c24231da80"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
 
 randomfill@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
+  integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
@@ -5332,6 +6059,7 @@ randomfill@^1.0.3:
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
   dependencies:
     deep-extend "^0.6.0"
     ini "~1.3.0"
@@ -5341,12 +6069,14 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
 read-cmd-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
+  integrity sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=
   dependencies:
     graceful-fs "^4.1.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+  integrity sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=
   dependencies:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
@@ -5354,6 +6084,7 @@ read-pkg-up@^1.0.1:
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  integrity sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
   dependencies:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
@@ -5361,6 +6092,7 @@ read-pkg-up@^2.0.0:
 read-pkg-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
+  integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
   dependencies:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
@@ -5368,6 +6100,7 @@ read-pkg-up@^3.0.0:
 read-pkg@^1.0.0, read-pkg@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+  integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
   dependencies:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
@@ -5376,6 +6109,7 @@ read-pkg@^1.0.0, read-pkg@^1.1.0:
 read-pkg@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  integrity sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
   dependencies:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
@@ -5384,14 +6118,16 @@ read-pkg@^2.0.0:
 read-pkg@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
   dependencies:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
-  resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -5402,37 +6138,41 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
+  integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
   dependencies:
-    graceful-fs "^4.1.2"
-    minimatch "^3.0.2"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
     readable-stream "^2.0.2"
-    set-immediate-shim "^1.0.1"
 
 readline2@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
+  integrity sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=
   dependencies:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
 realpath-native@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.2.tgz#cd51ce089b513b45cf9b1516c82989b51ccc6560"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
+  integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
   dependencies:
     resolve "^1.1.6"
 
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
+  integrity sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
@@ -5440,6 +6180,7 @@ redent@^1.0.0:
 redent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
   dependencies:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
@@ -5447,28 +6188,34 @@ redent@^2.0.0:
 redux-promise@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/redux-promise/-/redux-promise-0.5.3.tgz#e97e6c9d3bf376eacb79babe6d906da20112d6d8"
+  integrity sha1-6X5snTvzdurLebq+bZBtogES1tg=
   dependencies:
     flux-standard-action "^0.6.1"
 
 redux-thunk@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
 regenerate@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
+  integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
 regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
+  integrity sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==
   dependencies:
     babel-runtime "^6.18.0"
     babel-types "^6.19.0"
@@ -5477,12 +6224,14 @@ regenerator-transform@^0.10.0:
 regex-cache@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
+  integrity sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
   dependencies:
     is-equal-shallow "^0.1.3"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
@@ -5490,6 +6239,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
+  integrity sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=
   dependencies:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"
@@ -5498,6 +6248,7 @@ regexpu-core@^2.0.0:
 registry-auth-token@^3.0.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
+  integrity sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==
   dependencies:
     rc "^1.1.6"
     safe-buffer "^5.0.1"
@@ -5505,60 +6256,71 @@ registry-auth-token@^3.0.1:
 registry-url@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
   dependencies:
     rc "^1.0.1"
 
 regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
+  integrity sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=
 
 regjsparser@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
+  integrity sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=
   dependencies:
     jsesc "~0.5.0"
 
 relative@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/relative/-/relative-3.0.2.tgz#0dcd8ec54a5d35a3c15e104503d65375b5a5367f"
+  integrity sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=
   dependencies:
     isobject "^2.0.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
 repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
+  integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
 
-request-promise-core@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
   dependencies:
-    lodash "^4.13.1"
+    lodash "^4.17.11"
 
 request-promise-native@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
+  integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
   dependencies:
-    request-promise-core "1.1.1"
-    stealthy-require "^1.1.0"
-    tough-cookie ">=2.3.3"
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
 
-request@^2.85.0, request@^2.87.0:
+request@^2.86.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -5584,22 +6346,27 @@ request@^2.85.0, request@^2.87.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
 require-from-string@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+  integrity sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=
 
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+  integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
 require-package-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
+  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
 
 require-uncached@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  integrity sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
@@ -5607,12 +6374,14 @@ require-uncached@^1.0.2:
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
+  integrity sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=
   dependencies:
     resolve-from "^3.0.0"
 
 resolve-dir@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
+  integrity sha1-shklmlYC+sXFxJatiUpujMQwJh4=
   dependencies:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
@@ -5620,28 +6389,34 @@ resolve-dir@^0.1.0:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+  integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
 
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+  integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+resolve@^1.1.6, resolve@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
+  integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
   dependencies:
-    path-parse "^1.0.5"
+    path-parse "^1.0.6"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  integrity sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=
   dependencies:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
@@ -5649,6 +6424,7 @@ restore-cursor@^1.0.1:
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
@@ -5656,20 +6432,24 @@ restore-cursor@^2.0.0:
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 right-pad@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
+  integrity sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@~2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
-    glob "^7.0.5"
+    glob "^7.1.3"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
@@ -5677,18 +6457,21 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
 rollup-plugin-babel@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.7.tgz#5b13611f1ab8922497e9d15197ae5d8a23fe3b1e"
+  integrity sha512-bVe2y0z/V5Ax1qU8NX/0idmzIwJPdUGu8Xx3vXH73h0yGjxfv2gkFI82MBVg49SlsFlLTBadBHb67zy4TWM3hA==
   dependencies:
     rollup-pluginutils "^1.5.0"
 
 rollup-plugin-json@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-3.0.0.tgz#aeed2ff36e6c4fd0c60c4a8fc3d0884479e9dfce"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-3.1.0.tgz#7c1daf60c46bc21021ea016bd00863561a03321b"
+  integrity sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==
   dependencies:
-    rollup-pluginutils "^2.2.0"
+    rollup-pluginutils "^2.3.1"
 
 rollup-plugin-uglify@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-4.0.0.tgz#6eb471738f1ce9ba7d9d4bc43b71cba02417c8fb"
+  integrity sha512-f6W31EQLzxSEYfN3x6/lyljHqXSoCjXKcTsnwz3evQvHgU1+qTzU2SE0SIG7tbAvaCewp2UaZ5x3k6nYsxOP9A==
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.47"
     uglify-js "^3.3.25"
@@ -5696,20 +6479,23 @@ rollup-plugin-uglify@^4.0.0:
 rollup-pluginutils@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
+  integrity sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
 
-rollup-pluginutils@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.1.tgz#760d185ccc237dedc12d7ae48c6bcd127b4892d0"
+rollup-pluginutils@^2.3.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz#de43ab54965bbf47843599a7f3adceb723de38db"
+  integrity sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==
   dependencies:
-    estree-walker "^0.5.2"
-    micromatch "^2.3.11"
+    estree-walker "^0.6.0"
+    micromatch "^3.1.10"
 
 rollup@^0.63.5:
   version "0.63.5"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.63.5.tgz#5543eecac9a1b83b7e1be598b5be84c9c0a089db"
+  integrity sha512-dFf8LpUNzIj3oE0vCvobX6rqOzHzLBoblyFp+3znPbjiSmSvOoK2kMKx+Fv9jYduG1rvcCfCveSgEaQHjWRF6g==
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"
@@ -5717,74 +6503,79 @@ rollup@^0.63.5:
 rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+  integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
 
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+  integrity sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=
   dependencies:
     once "^1.3.0"
 
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  integrity sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=
   dependencies:
     rx-lite "*"
 
 rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+  integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+  integrity sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=
 
 rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
+  integrity sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=
 
 rxjs@^5.0.0-beta.11:
   version "5.5.12"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
+  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
   dependencies:
     symbol-observable "1.0.1"
 
-rxjs@^6.1.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.2.tgz#6a688b16c4e6e980e62ea805ec30648e1c60907f"
+rxjs@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
   dependencies:
     ret "~0.1.10"
 
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-
-samsam@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
-
-samsam@~1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sane@^2.0.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
+  integrity sha1-tNwYYcIbQn6SlQej51HiosuKs/o=
   dependencies:
     anymatch "^2.0.0"
     capture-exit "^1.2.0"
@@ -5800,22 +6591,22 @@ sane@^2.0.0:
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-
-set-immediate-shim@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
 set-value@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.2.0.tgz#73b0a6825c158c6a16a82bbdc95775bf2a825fab"
+  integrity sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=
   dependencies:
     isobject "^1.0.0"
     noncharacters "^1.1.0"
@@ -5823,6 +6614,7 @@ set-value@^0.2.0:
 set-value@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
@@ -5832,6 +6624,7 @@ set-value@^0.4.3:
 set-value@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
@@ -5841,10 +6634,12 @@ set-value@^2.0.0:
 setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
-  resolved "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
@@ -5852,16 +6647,19 @@ sha.js@^2.4.0, sha.js@^2.4.8:
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
   dependencies:
     shebang-regex "^1.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shelljs@0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
+  integrity sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -5870,6 +6668,7 @@ shelljs@0.7.6:
 shelljs@^0.7.5:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -5878,35 +6677,27 @@ shelljs@^0.7.5:
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-
-sinon-chai@^2.8.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.14.0.tgz#da7dd4cc83cd6a260b67cca0f7a9fdae26a1205d"
-
-sinon@^1.17.7:
-  version "1.17.7"
-  resolved "http://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
-  dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
   dependencies:
     define-property "^1.0.0"
     isobject "^3.0.0"
@@ -5915,12 +6706,14 @@ snapdragon-node@^2.0.1:
 snapdragon-util@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
   dependencies:
     kind-of "^3.2.0"
 
 snapdragon@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
   dependencies:
     base "^0.11.1"
     debug "^2.2.0"
@@ -5934,12 +6727,14 @@ snapdragon@^0.8.1:
 sort-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
   dependencies:
     is-plain-obj "^1.0.0"
 
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
   dependencies:
     atob "^2.1.1"
     decode-uri-component "^0.2.0"
@@ -5950,12 +6745,14 @@ source-map-resolve@^0.5.0:
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
   dependencies:
     source-map "^0.5.6"
 
 source-map-support@^0.5.0:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
+  integrity sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -5963,107 +6760,125 @@ source-map-support@^0.5.0:
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
 source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spawn-sync@^1.0.15:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
+  integrity sha1-sAeZVX63+wyDdsKdROih6mfldHY=
   dependencies:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
 
 spdx-correct@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
+  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
 
 spdx-exceptions@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
+  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
 
 spdx-expression-parse@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
   dependencies:
     spdx-exceptions "^2.1.0"
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz#e2a303236cac54b04031fa7a5a79c7e701df852f"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
+  integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
 
 split2@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
+  integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
   dependencies:
     through2 "^2.0.2"
 
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
-    dashdash "^1.12.0"
-    getpass "^0.1.1"
-    safer-buffer "^2.0.2"
-  optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
     ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
     jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
 stack-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
+  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
 staged-git-files@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+  integrity sha1-15fhtVHKemOd7AI33G60u5vhfTU=
 
 starts-with@^1.0.0, starts-with@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/starts-with/-/starts-with-1.0.2.tgz#16793a729d89d4cf3d4fb2eda2f908ae357f196f"
+  integrity sha1-Fnk6cp2J1M89T7LtovkIrjV/GW8=
 
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stealthy-require@^1.1.0:
+stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
 stream-browserify@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
+  integrity sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
@@ -6071,6 +6886,7 @@ stream-browserify@^2.0.1:
 stream-http@^2.7.2:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -6081,10 +6897,12 @@ stream-http@^2.7.2:
 stream-to-observable@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
+  integrity sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=
 
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
+  integrity sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
@@ -6092,6 +6910,7 @@ string-length@^2.0.0:
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
   dependencies:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
@@ -6100,67 +6919,93 @@ string-width@^1.0.1:
 "string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@^1.0.0, string_decoder@~1.1.1:
+string_decoder@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
 stringify-object@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.2.tgz#9853052e5a88fb605a44cd27445aa257ad7ffbcd"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
   dependencies:
-    get-own-enumerable-property-symbols "^2.0.1"
+    get-own-enumerable-property-symbols "^3.0.0"
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
+  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
+  dependencies:
+    ansi-regex "^4.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+  integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
   dependencies:
     is-utf8 "^0.2.0"
 
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
+  integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
 
 strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 strong-log-transformer@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz#f7fb93758a69a571140181277eea0c2eb1301fa3"
+  integrity sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=
   dependencies:
     byline "^5.0.0"
     duplexer "^0.1.1"
@@ -6171,36 +7016,43 @@ strong-log-transformer@^1.0.6:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
 supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
   dependencies:
     has-flag "^1.0.0"
 
 supports-color@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  integrity sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=
   dependencies:
     has-flag "^2.0.0"
 
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
 symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+  integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+  integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
 table@^3.7.8:
   version "3.8.3"
-  resolved "http://registry.npmjs.org/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+  integrity sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=
   dependencies:
     ajv "^4.7.0"
     ajv-keywords "^1.0.0"
@@ -6210,13 +7062,14 @@ table@^3.7.8:
     string-width "^2.0.0"
 
 tar@^4:
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
   dependencies:
-    chownr "^1.0.1"
+    chownr "^1.1.1"
     fs-minipass "^1.2.5"
-    minipass "^2.3.3"
-    minizlib "^1.1.0"
+    minipass "^2.3.4"
+    minizlib "^1.1.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
@@ -6224,10 +7077,12 @@ tar@^4:
 temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+  integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
 
 temp-write@^3.3.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.4.0.tgz#8cff630fb7e9da05f047c74ce4ce4d685457d492"
+  integrity sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=
   dependencies:
     graceful-fs "^4.1.2"
     is-stream "^1.1.0"
@@ -6239,6 +7094,7 @@ temp-write@^3.3.0:
 tempfile@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-1.1.1.tgz#5bcc4eaecc4ab2c707d8bc11d99ccc9a2cb287f2"
+  integrity sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=
   dependencies:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
@@ -6246,6 +7102,7 @@ tempfile@^1.1.1:
 test-exclude@^4.2.1:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.3.tgz#a9a5e64474e4398339245a0a769ad7c2f4a97c20"
+  integrity sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==
   dependencies:
     arrify "^1.0.1"
     micromatch "^2.3.11"
@@ -6254,75 +7111,90 @@ test-exclude@^4.2.1:
     require-main-filename "^1.0.1"
 
 text-extensions@^1.0.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.8.0.tgz#6f343c62268843019b21a616a003557bdb952d2b"
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
+  integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+  integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
 through2@^2.0.0, through2@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
   dependencies:
-    readable-stream "^2.1.5"
+    readable-stream "~2.3.6"
     xtend "~4.0.1"
 
 through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   version "2.3.8"
-  resolved "http://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 timers-browserify@^2.0.4:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
+  integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
 
 tmp@^0.0.29:
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
+  integrity sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=
   dependencies:
     os-tmpdir "~1.0.1"
 
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
+  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+  integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
 
 to-regex-range@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
@@ -6330,15 +7202,25 @@ to-regex-range@^2.1.0:
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
   dependencies:
     define-property "^2.0.2"
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
+tough-cookie@^2.3.3, tough-cookie@^2.3.4:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
@@ -6346,64 +7228,68 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
 
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
 
 trim-newlines@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
+  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
 
 trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
+  integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+  integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
-
-type-detect@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
-
-type-detect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript-babel-jest@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/typescript-babel-jest/-/typescript-babel-jest-1.0.5.tgz#5f5acffb7495cb050601f056e4ec07ac52c69445"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/typescript-babel-jest/-/typescript-babel-jest-1.0.6.tgz#f9b9ab1fd83be44674cb139e4f0fd368591dc4a5"
+  integrity sha512-S+b3V+WsTAXlfdeh9JFIMrfMZCCP++T6ThzPIrtuujunsRZYXpZzXR5/SIV4euBKLrreMbK+Zw9JPx9dZIuKZQ==
   dependencies:
     app-root-path "2.0.1"
     babel-jest "20.0.3"
@@ -6412,10 +7298,12 @@ typescript-babel-jest@^1.0.5:
 typescript@^2.2.1, typescript@^2.4.1:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 uglify-js@^3.1.4, uglify-js@^3.3.25:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
+  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
   dependencies:
     commander "~2.17.1"
     source-map "~0.6.1"
@@ -6423,10 +7311,12 @@ uglify-js@^3.1.4, uglify-js@^3.3.25:
 unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+  integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  integrity sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
   dependencies:
     arr-union "^3.1.0"
     get-value "^2.0.6"
@@ -6436,10 +7326,12 @@ union-value@^1.0.0:
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  integrity sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
@@ -6447,20 +7339,31 @@ unset-value@^1.0.0:
 unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+  integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
 
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
   dependencies:
     prepend-http "^1.0.1"
 
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
@@ -6468,24 +7371,29 @@ url@^0.11.0:
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+  integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
+  integrity sha1-K1viOjK2Onyd640PKNSFcko98ZA=
 
 user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  integrity sha1-nHC/2Babwdy/SGBODwS4tJzenp8=
   dependencies:
     os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util.promisify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
   dependencies:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
@@ -6493,38 +7401,38 @@ util.promisify@^1.0.0:
 util@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
-"util@>=0.10.3 <1":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.11.0.tgz#c5f391beb244103d799b21077a926fef8769e1fb"
-  dependencies:
-    inherits "2.0.3"
-
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+util@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
 
 uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
+  integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 v8flags@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
+  integrity sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=
   dependencies:
     user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
@@ -6532,6 +7440,7 @@ validate-npm-package-license@^3.0.1:
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
   dependencies:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
@@ -6540,24 +7449,28 @@ verror@1.10.0:
 vm-browserify@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
+  integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
   dependencies:
     indexof "0.0.1"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
 
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
 
 watch@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
+  integrity sha1-KAlUdsbffJDJYxOJkMClQj60uYY=
   dependencies:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
@@ -6565,26 +7478,31 @@ watch@~0.18.0:
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz#63fb016b7435b795d9025632c086a5209dbd2621"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
-    iconv-lite "0.4.23"
+    iconv-lite "0.4.24"
 
-whatwg-mimetype@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
+whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
 whatwg-url@^6.4.1:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
@@ -6593,6 +7511,7 @@ whatwg-url@^6.4.1:
 whatwg-url@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  integrity sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
@@ -6601,34 +7520,41 @@ whatwg-url@^7.0.0:
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
 which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
 
 word-wrap@^1.0.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
-  resolved "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
@@ -6636,10 +7562,12 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
+  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
@@ -6648,6 +7576,7 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
 write-json-file@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
+  integrity sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=
   dependencies:
     detect-indent "^5.0.0"
     graceful-fs "^4.1.2"
@@ -6659,6 +7588,7 @@ write-json-file@^2.2.0:
 write-pkg@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/write-pkg/-/write-pkg-3.2.0.tgz#0e178fe97820d389a8928bc79535dbe68c2cff21"
+  integrity sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
@@ -6666,50 +7596,60 @@ write-pkg@^3.1.0:
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  integrity sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=
   dependencies:
     mkdirp "^0.5.1"
 
 ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
   dependencies:
     async-limiter "~1.0.0"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
   dependencies:
     camelcase "^4.1.0"
 
 yargs-parser@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
   dependencies:
     camelcase "^4.1.0"
 
 yargs@^10.0.3:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+  integrity sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
   dependencies:
     cliui "^4.0.0"
     decamelize "^1.1.1"
@@ -6727,6 +7667,7 @@ yargs@^10.0.3:
 yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  integrity sha1-YpmpBVsc78lp/355wdkY3Osiw2A=
   dependencies:
     camelcase "^4.1.0"
     cliui "^3.2.0"


### PR DESCRIPTION
#### Reference issue: [#88](https://github.com/trivago/melody/issues/88)

#### What changed in this PR:

- Removes chai and sinon
- Migrate tests to use jest matchers.

~~Note: I am waiting https://github.com/trivago/melody/pull/100 to be merged to update changelog.~~