### PR TITLE
Warn about usage of non-breaking space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - incorrect 'is' method call in melody-types [#20](https://github.com/trivago/melody/issues/20)
 - getFocusedPath can break on IE11 for svg elements [#57](https://github.com/trivago/melody/issues/57)
-- Better error message for Non-breakable space tokens [#85](https://github.com/trivago/melody/issues/85)
+- Warn about usage of non-breaking space [#85](https://github.com/trivago/melody/issues/85)
 
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - incorrect 'is' method call in melody-types [#20](https://github.com/trivago/melody/issues/20)
 - getFocusedPath can break on IE11 for svg elements [#57](https://github.com/trivago/melody/issues/57)
+- Better error message for Non-breakable space tokens [#85](https://github.com/trivago/melody/issues/85)
 
 
 ### Chore & Maintenance

--- a/packages/melody-compiler/__tests__/__fixtures__/error/nonbreakable_space.template
+++ b/packages/melody-compiler/__tests__/__fixtures__/error/nonbreakable_space.template
@@ -1,0 +1,1 @@
+{{ 'success_msg' | sort }}

--- a/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -2277,6 +2277,13 @@ Example:
 This is the placeholder content that will be shown to your users while the async component is being loaded."
 `;
 
+exports[`Compiler should fail transforming nonbreakable space.template 1`] = `
+"ERROR: Unsupported character: Non-breaking space
+> 1 | {{ 'success_msg' | sort }}
+    |                   ^
+  2 | "
+`;
+
 exports[`Compiler should fail transforming unknown filter.template 1`] = `
 "Unknown filter \\"unknown\\"
 > 1 | {{ test | unknown }}

--- a/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -2278,7 +2278,7 @@ This is the placeholder content that will be shown to your users while the async
 `;
 
 exports[`Compiler should fail transforming nonbreakable space.template 1`] = `
-"ERROR: Unsupported character: Non-breaking space
+"ERROR: Unsupported token: Non-breaking space
 > 1 | {{ 'success_msg' | sort }}
     |                   ^
   2 | "

--- a/packages/melody-parser/src/Lexer.js
+++ b/packages/melody-parser/src/Lexer.js
@@ -355,6 +355,11 @@ export default class Lexer {
                 } else if (CHAR_TO_TOKEN.hasOwnProperty(c)) {
                     input.next();
                     return this.createToken(CHAR_TO_TOKEN[c], pos);
+                } else if (c === ' ') {
+                    return this.error(
+                        'Unsupported token: Non-breaking space',
+                        pos
+                    );
                 } else {
                     return this.error(`Unknown token ${c}`, pos);
                 }

--- a/packages/melody-parser/src/Lexer.js
+++ b/packages/melody-parser/src/Lexer.js
@@ -355,7 +355,7 @@ export default class Lexer {
                 } else if (CHAR_TO_TOKEN.hasOwnProperty(c)) {
                     input.next();
                     return this.createToken(CHAR_TO_TOKEN[c], pos);
-                } else if (c === ' ') {
+                } else if (c === '\xa0') {
                     return this.error(
                         'Unsupported token: Non-breaking space',
                         pos


### PR DESCRIPTION
#### Reference issue: [#85](https://github.com/trivago/melody/issues/85)

#### What changed in this PR:

This PR adds a warning about usage of non-breaking space in a template. Regarding this issue, a unit test is added.

