### PR TITLE
Allow empty alt attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+### Fixes
+- Allow empty-string `alt` attribute [#111](https://github.com/trivago/melody/pull/111)
+
 ### Chore & Maintenance
 - Removes `Chai` and `Sinon` support, Migrates tests to use `Jest`'s matchers. [#103](https://github.com/trivago/melody/pull/103)
 

--- a/packages/melody-runtime/__tests__/FilterSpec.js
+++ b/packages/melody-runtime/__tests__/FilterSpec.js
@@ -81,6 +81,13 @@ describe('Twig filter runtime', function() {
             expect(actual).toEqual(expected);
         });
 
+        it('should keep empty string for alt', function() {
+            const input = { alt: '' };
+            const expected = ['alt', ''];
+            const actual = attrs(input);
+            expect(actual).toEqual(expected);
+        });
+
         it('should ignore inherited properties', function() {
             const input = Object.create({ a: 2 });
             input.b = 1;

--- a/packages/melody-runtime/src/filters.js
+++ b/packages/melody-runtime/src/filters.js
@@ -38,7 +38,10 @@ export function attrs(attrMap: Object) {
         const value = attrMap[attr];
         attrArray.push(
             attr,
-            value === false || value === null || value === 0 || value === ''
+            value === false ||
+                value === null ||
+                value === 0 ||
+                (value === '' && attr !== 'alt')
                 ? undefined
                 : value
         );


### PR DESCRIPTION
#### Reference issue: [#38](https://github.com/trivago/melody/issues/38)

#### What changed in this PR:

Allows empty-string alt attributes

Fixes #38