### PR TITLE
Drop bundled dependencies

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0-rc.4",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/packages/melody-code-frame/package.json
+++ b/packages/melody-code-frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-code-frame",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-compiler/package.json
+++ b/packages/melody-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-compiler",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",
@@ -14,7 +14,7 @@
     "babel-template": "^6.8.0",
     "babel-types": "^6.8.1",
     "lodash": "^4.12.0",
-    "melody-code-frame": "1.2.0-21.0",
+    "melody-code-frame": "1.2.0-21.1",
     "random-seed": "^0.3.0"
   },
   "peerDependencies": {
@@ -31,8 +31,8 @@
     "random-seed"
   ],
   "devDependencies": {
-    "melody-extension-core": "1.2.0-21.0",
-    "melody-plugin-idom": "1.2.0-21.0",
+    "melody-extension-core": "1.2.0-21.1",
+    "melody-plugin-idom": "1.2.0-21.1",
     "rollup-plugin-babel": "^2.6.1"
   }
 }

--- a/packages/melody-compiler/package.json
+++ b/packages/melody-compiler/package.json
@@ -24,12 +24,6 @@
     "melody-traverse": "^1.1.0",
     "melody-types": "^1.1.0"
   },
-  "bundledDependencies": [
-    "babel-types",
-    "babel-generator",
-    "babel-template",
-    "random-seed"
-  ],
   "devDependencies": {
     "melody-extension-core": "1.2.0-21.1",
     "melody-plugin-idom": "1.2.0-21.1",

--- a/packages/melody-component/package.json
+++ b/packages/melody-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-component",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-devtools/package.json
+++ b/packages/melody-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-devtools",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-extension-core/package.json
+++ b/packages/melody-extension-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-extension-core",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-extension-core/package.json
+++ b/packages/melody-extension-core/package.json
@@ -15,11 +15,6 @@
     "lodash": "^4.12.0",
     "shortid": "^2.2.6"
   },
-  "bundledDependencies": [
-    "babel-types",
-    "babel-template",
-    "shortid"
-  ],
   "peerDependencies": {
     "melody-idom": "^1.1.0",
     "melody-parser": "^1.1.0",

--- a/packages/melody-hoc/package.json
+++ b/packages/melody-hoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-hoc",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",
@@ -11,13 +11,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "lodash": "^4.15.0",
-    "melody-component": "1.2.0-21.0"
+    "melody-component": "1.2.0-21.1"
   },
   "peerDependencies": {
     "melody-idom": "1.1.0"
   },
   "devDependencies": {
-    "melody-idom": "1.2.0-21.0",
+    "melody-idom": "1.2.0-21.1",
     "redux": "^3.6.0"
   }
 }

--- a/packages/melody-hooks/package.json
+++ b/packages/melody-hooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "melody-hooks",
-    "version": "1.2.0-21.0",
+    "version": "1.2.0-21.1",
     "description": "",
     "main": "./lib/index.js",
     "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-idom/package.json
+++ b/packages/melody-idom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-idom",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-jest-transform/package.json
+++ b/packages/melody-jest-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-jest-transform",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "scripts": {
@@ -11,11 +11,11 @@
   "dependencies": {
     "babel-core": "^6.18.0",
     "find-babel-config": "^1.0.1",
-    "melody-compiler": "1.2.0-21.0",
-    "melody-extension-core": "1.2.0-21.0"
+    "melody-compiler": "1.2.0-21.1",
+    "melody-extension-core": "1.2.0-21.1"
   },
   "devDependencies": {
-    "melody-plugin-idom": "1.2.0-21.0",
+    "melody-plugin-idom": "1.2.0-21.1",
     "rollup-plugin-babel": "^2.6.1"
   },
   "peerDependencies": {

--- a/packages/melody-loader/package.json
+++ b/packages/melody-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-loader",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",
@@ -12,16 +12,16 @@
   "dependencies": {
     "loader-utils": "^1.1.0",
     "lodash": "^4.12.0",
-    "melody-compiler": "1.2.0-21.0",
-    "melody-extension-core": "1.2.0-21.0",
-    "melody-runtime": "1.2.0-21.0"
+    "melody-compiler": "1.2.0-21.1",
+    "melody-extension-core": "1.2.0-21.1",
+    "melody-runtime": "1.2.0-21.1"
   },
   "peerDependencies": {
     "melody-idom": "1.1.0"
   },
   "devDependencies": {
-    "melody-idom": "1.2.0-21.0",
-    "melody-plugin-idom": "1.2.0-21.0",
+    "melody-idom": "1.2.0-21.1",
+    "melody-plugin-idom": "1.2.0-21.1",
     "mkdirp": "^0.5.1",
     "mz": "^2.6.0",
     "rimraf": "^2.6.1",

--- a/packages/melody-parser/package.json
+++ b/packages/melody-parser/package.json
@@ -14,9 +14,6 @@
     "lodash": "^4.12.0",
     "melody-code-frame": "1.2.0-21.1"
   },
-  "bundledDependencies": [
-    "he"
-  ],
   "peerDependencies": {
     "melody-types": "^1.1.0"
   },

--- a/packages/melody-parser/package.json
+++ b/packages/melody-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-parser",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",
@@ -12,7 +12,7 @@
   "dependencies": {
     "he": "^1.1.0",
     "lodash": "^4.12.0",
-    "melody-code-frame": "1.2.0-21.0"
+    "melody-code-frame": "1.2.0-21.1"
   },
   "bundledDependencies": [
     "he"

--- a/packages/melody-plugin-idom/package.json
+++ b/packages/melody-plugin-idom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-plugin-idom",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-plugin-idom/package.json
+++ b/packages/melody-plugin-idom/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "babel-types": "^6.8.1"
   },
-  "bundledDependencies": [
-    "babel-types"
-  ],
   "peerDependencies": {
     "melody-types": "^1.1.0"
   },

--- a/packages/melody-plugin-jsx/package.json
+++ b/packages/melody-plugin-jsx/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "babel-types": "^6.8.1"
   },
-  "bundledDependencies": [
-    "babel-types"
-  ],
   "peerDependencies": {
     "melody-traverse": "^1.1.0",
     "melody-types": "^1.1.0"

--- a/packages/melody-plugin-jsx/package.json
+++ b/packages/melody-plugin-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-plugin-jsx",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",
@@ -20,8 +20,8 @@
     "melody-types": "^1.1.0"
   },
   "devDependencies": {
-    "melody-compiler": "1.2.0-21.0",
-    "melody-extension-core": "1.2.0-21.0",
+    "melody-compiler": "1.2.0-21.1",
+    "melody-extension-core": "1.2.0-21.1",
     "rollup-plugin-babel": "^2.6.1"
   }
 }

--- a/packages/melody-plugin-load-functions/package.json
+++ b/packages/melody-plugin-load-functions/package.json
@@ -12,9 +12,6 @@
     "dependencies": {
         "babel-types": "^6.8.1"
     },
-    "bundledDependencies": [
-        "babel-types"
-    ],
     "peerDependencies": {
         "melody-types": "^1.1.0"
     },

--- a/packages/melody-plugin-load-functions/package.json
+++ b/packages/melody-plugin-load-functions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "melody-plugin-load-functions",
-    "version": "1.2.0-21.0",
+    "version": "1.2.0-21.1",
     "description": "",
     "main": "./lib/index.js",
     "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-plugin-skip-if/package.json
+++ b/packages/melody-plugin-skip-if/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-plugin-skip-if",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-plugin-skip-if/package.json
+++ b/packages/melody-plugin-skip-if/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "babel-types": "^6.8.1"
   },
-  "bundledDependencies": [
-    "babel-types"
-  ],
   "peerDependencies": {
     "melody-types": "^1.1.0"
   },

--- a/packages/melody-redux/package.json
+++ b/packages/melody-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-redux",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",
@@ -10,7 +10,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "melody-component": "1.2.0-21.0"
+    "melody-component": "1.2.0-21.1"
   },
   "peerDependencies": {
     "melody-idom": "^1.1.0"

--- a/packages/melody-runtime/package.json
+++ b/packages/melody-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-runtime",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-streams/package.json
+++ b/packages/melody-streams/package.json
@@ -1,6 +1,6 @@
 {
     "name": "melody-streams",
-    "version": "1.2.0-21.0",
+    "version": "1.2.0-21.1",
     "description": "",
     "main": "./lib/index.js",
     "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-traverse/package.json
+++ b/packages/melody-traverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-traverse",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-types/package.json
+++ b/packages/melody-types/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "babel-types": "^6.8.1"
   },
-  "bundledDependencies": [
-    "babel-types"
-  ],
   "devDependencies": {
     "rollup-plugin-babel": "^2.6.1"
   }

--- a/packages/melody-types/package.json
+++ b/packages/melody-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-types",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",

--- a/packages/melody-util/package.json
+++ b/packages/melody-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melody-util",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "",
   "main": "./lib/index.js",
   "jsnext:main": "./lib/index.esm.js",
@@ -10,10 +10,10 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "melody-component": "1.2.0-21.0"
+    "melody-component": "1.2.0-21.1"
   },
   "devDependencies": {
-    "melody-idom": "1.2.0-21.0",
+    "melody-idom": "1.2.0-21.1",
     "rollup-plugin-babel": "^2.6.1"
   }
 }

--- a/packages/neutrino-preset-melody/package.json
+++ b/packages/neutrino-preset-melody/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutrino-preset-melody",
-  "version": "1.2.0-21.0",
+  "version": "1.2.0-21.1",
   "description": "Neutrino preset for building melody web applications",
   "main": "index.js",
   "author": "Efe Gürkan YALAMAN <efe-gurkan.yalaman@trivago.com>",
@@ -10,7 +10,7 @@
     "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "deepmerge": "^1.5.0",
-    "melody-loader": "1.2.0-21.0",
+    "melody-loader": "1.2.0-21.1",
     "neutrino-middleware-compile-loader": "^6.1.4",
     "neutrino-middleware-loader-merge": "^6.1.4",
     "neutrino-preset-web": "^6.1.4"


### PR DESCRIPTION
#### What changed in this PR:

Removed `bundledDependencies` to avoid problems with yarn.
