### PR TITLE
Create new object for sub context

### DIFF
--- a/packages/melody-runtime/src/context.js
+++ b/packages/melody-runtime/src/context.js
@@ -23,9 +23,5 @@ export function createSubContext(
     parent: Object,
     customValues?: Object
 ): Object {
-    const subContext = Object.create(parent);
-    if (customValues) {
-        Object.assign(subContext, customValues);
-    }
-    return subContext;
+    return Object.assign({}, parent, customValues);
 }


### PR DESCRIPTION
#### What changed in this PR:

While working with extended templates, properties that are transferend in prototype context will be lost in child components when being copied.
This fix avoids this as it merges property without writing to the prototype.
