### PR TITLE
Fixing scope for dispatchCustomEvent on melody stream components.

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         },
         {
             "path": "./packages/melody-streams/lib/index.js",
-            "maxSize": "1.52 kB"
+            "maxSize": "1.53 kB"
         }
     ]
 }

--- a/packages/melody-streams/src/component.js
+++ b/packages/melody-streams/src/component.js
@@ -53,6 +53,7 @@ function Component(element) {
 Object.assign(Component.prototype, {
     type: 'streaming',
     apply(props) {
+        const _this = this;
         this.propsStream.next(props);
         if (this.subscriptions.length === 0) {
             const t = this.getTransform({
@@ -61,7 +62,7 @@ Object.assign(Component.prototype, {
                         ...options,
                         detail,
                     });
-                    this.el.dispatchEvent(event);
+                    _this.el.dispatchEvent(event);
                 },
                 props: this.propsStream,
                 updates: this.updates,


### PR DESCRIPTION
#### What changed in this PR:
Fixing scope issue of `dispatchCustomEvent`in melody-streams component.

While calling `dispatchCustomEvent` we lost the correct scope for this function to work. This change stores the correct context for later calling `this.el.dispatchEvent`.

