### PR TITLE
Fixed binding of dispatchCustomEvent function

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         },
         {
             "path": "./packages/melody-streams/lib/index.js",
-            "maxSize": "1.52 kB"
+            "maxSize": "1.53 kB"
         }
     ]
 }

--- a/packages/melody-streams/__tests__/dispatchCustomEventSpec.js
+++ b/packages/melody-streams/__tests__/dispatchCustomEventSpec.js
@@ -1,0 +1,44 @@
+import { elementOpen, elementClose } from 'melody-idom';
+
+import { createComponent, render } from '../src';
+
+import { first, tap, catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+describe('dispatchCustomEvent', () => {
+    it(`dispatches custom event properly`, done => {
+        const root = document.createElement('div');
+        const eventListenerCallback = jest.fn(() => done());
+
+        root.addEventListener('myCustomEvent', eventListenerCallback);
+
+        const template = {
+            render() {
+                elementOpen('div', null, null);
+                elementClose('div');
+            },
+        };
+
+        const C = ({ props, updates, subscribe, dispatchCustomEvent }) => {
+            subscribe(
+                updates.pipe(
+                    first(),
+                    tap(() => {
+                        dispatchCustomEvent('myCustomEvent');
+                    }),
+                    catchError(err => {
+                        done(err);
+                        return of(err);
+                    })
+                )
+            );
+
+            return props;
+        };
+
+        const TestComponent = createComponent(C, template);
+        render(root, TestComponent);
+
+        expect(eventListenerCallback).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/melody-streams/src/component.js
+++ b/packages/melody-streams/src/component.js
@@ -56,7 +56,7 @@ Object.assign(Component.prototype, {
         this.propsStream.next(props);
         if (this.subscriptions.length === 0) {
             const t = this.getTransform({
-                dispatchCustomEvent(eventName, detail, options = {}) {
+                dispatchCustomEvent: (eventName, detail, options = {}) => {
                     const event = new CustomEvent(eventName, {
                         ...options,
                         detail,


### PR DESCRIPTION
#### What changed in this PR:
Using an arrow function to properly bind `this` inside the `dispatchCustomEvent` function.

