### PR TITLE
Invoke the unsubscribe method on the subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix melody-stream not rerendering in some cases [#112](https://github.com/trivago/melody/pull/112)
 - Warn about usage of non-breaking space [#107](https://github.com/trivago/melody/pull/107)
 - Fixed bindings of dispatchCustomEvent in `melody-streams` [#117](https://github.com/trivago/melody/pull/117)
+- Fixed `combineRefs` unsubscription in `melody-streams` [#120](https://github.com/trivago/melody/pull/120)
 
 ### Chore & Maintenance
 - Removes `Chai` and `Sinon` support, Migrates tests to use `Jest`'s matchers. [#103](https://github.com/trivago/melody/pull/103)

--- a/packages/melody-streams/src/operators/combineRefs.js
+++ b/packages/melody-streams/src/operators/combineRefs.js
@@ -18,7 +18,7 @@ export const combineRefs = (...handlers) => el => {
     const subscriptions = handlers.map(fn => fn(el));
     return {
         unsubscribe() {
-            subscriptions.forEach(fn => fn && fn());
+            subscriptions.forEach(fn => fn && fn.unsubscribe());
             subscriptions.length = 0;
         },
     };


### PR DESCRIPTION
#### What changed in this PR:

`combineRefs` invoked the subscription object directly instead of calling the `unsubscribe` method on it.
