### PR TITLE
Adding operator attachEventWithElement

### DIFF
--- a/packages/melody-streams/__tests__/__snapshots__/attachEventWithElementSpec.js.snap
+++ b/packages/melody-streams/__tests__/__snapshots__/attachEventWithElementSpec.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`attachEventWithElement should attach a click handler 1`] = `"[{\\"type\\":\\"click\\"},{\\"type\\":\\"click\\"},{\\"type\\":\\"click\\"}]"`;
+
+exports[`attachEventWithElement should attach multiple handlers 1`] = `"[{\\"type\\":\\"click\\"},{\\"type\\":\\"click\\"},{\\"type\\":\\"click\\"},{\\"type\\":\\"mouseenter\\"},{\\"type\\":\\"mouseenter\\"},{\\"type\\":\\"mouseenter\\"}]"`;

--- a/packages/melody-streams/__tests__/attachEventWithElementSpec.js
+++ b/packages/melody-streams/__tests__/attachEventWithElementSpec.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2019 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { attachEventWithElement } from '../src';
+import { applyGradualyAndComplete } from './util/testHelpers';
+import { createMouseEvent } from './util/mouseEvent';
+
+const dispatchClick = createMouseEvent('click');
+const dispatchMouseEnter = createMouseEvent('mouseenter');
+
+describe('attachEventWithElement', () => {
+    it('should attach a click handler', async () => {
+        const el = document.createElement('div');
+        const [refHandler, subj, originEl] = attachEventWithElement('click');
+        refHandler(el);
+        applyGradualyAndComplete(subj, dispatchClick(el), [
+            undefined,
+            undefined,
+            undefined,
+        ]).then(handlers => {
+            expect(JSON.stringify(handlers)).toMatchSnapshot();
+            expect(el).toBe(originEl.value);
+        });
+    });
+
+    it('should attach multiple handlers', async () => {
+        const el = document.createElement('div');
+        const [refHandler, subj, originEl] = attachEventWithElement(
+            'click',
+            'mouseenter'
+        );
+        refHandler(el);
+        applyGradualyAndComplete(
+            subj,
+            [dispatchClick(el), dispatchMouseEnter(el)],
+            [undefined, undefined, undefined]
+        ).then(handlers => {
+            expect(JSON.stringify(handlers)).toMatchSnapshot();
+            expect(el).toBe(originEl.value);
+        });
+    });
+});

--- a/packages/melody-streams/src/operators/attachEventWithElement.js
+++ b/packages/melody-streams/src/operators/attachEventWithElement.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 trivago N.V.
+ * Copyright 2019 trivago N.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
-export { createComponent } from './component';
-export { render } from './render';
-export { createState } from './operators/createState';
-export { attachEvent } from './operators/attachEvent';
-export { attachEventWithElement } from './operators/attachEventWithElement';
-export { withElement } from './operators/withElement';
-export { combine } from './operators/combine';
-export { combineRefs } from './operators/combineRefs';
+import { attachEvent } from './attachEvent';
+import { withElement } from './withElement';
+import { combineRefs } from './combineRefs';
+import { of } from 'rxjs';
+
+export const attachEventWithElement = (...events) => {
+    const eventsAndElement = [
+        attachEvent(...events),
+        withElement(el => of(el), null),
+    ];
+    const refHandler = combineRefs(
+        ...eventsAndElement.map(([handler]) => handler)
+    );
+    const streams = eventsAndElement.map(([_, stream]) => stream);
+    return [refHandler, ...streams];
+};


### PR DESCRIPTION
#### What changed in this PR:

This PR adds the operator `attachEventWIthElement` which extends the already existing `attachEvent` operator by returning an observable that will contains the el reference where the eventHandler(s) are attached to.

