### PR TITLE
Do not log emission melody-streams warning in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## master
+- Do not log warning for component first emission in `melody-streams` in production [#128](https://github.com/trivago/melody/pull/128)
 
 ## 1.2.0
 

--- a/packages/melody-streams/src/component.js
+++ b/packages/melody-streams/src/component.js
@@ -65,11 +65,14 @@ Object.assign(Component.prototype, {
                 updates: this.updates,
                 subscribe: obs => this.subscriptions.push(obs.subscribe()),
             });
-            const warningSubscription = warningTimer.subscribe();
+            const warningSubscription = process.env.NODE_ENV !== 'production'
+                ? warningTimer.subscribe()
+                : null;
             const s = t.pipe(distinctUntilChanged(shallowEqual)).subscribe(
                 state => {
-                    if (!warningSubscription.closed)
+                    if (warningSubscription && !warningSubscription.closed) {
                         warningSubscription.unsubscribe();
+                    }
                     this.state = state;
                     enqueueComponent(this);
                 },


### PR DESCRIPTION
#### What changed in this PR:

This PR removes the log of `'Warning: Your Component did not emit any state updates for at least 500ms.'` in production.

