### PR TITLE
Removes prefetch for async components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 - Do not log warning for component first emission in `melody-streams` in production [#128](https://github.com/trivago/melody/pull/128)
+- Remove prefetch for async components [#130](https://github.com/trivago/melody/pull/130)
 
 ## 1.2.0
 

--- a/packages/melody-plugin-idom/src/visitors/mount.js
+++ b/packages/melody-plugin-idom/src/visitors/mount.js
@@ -108,24 +108,8 @@ export default {
                 }
 
                 if (isAsync) {
-                    /* webpackPrefetch: true */
                     const source = path.node.source;
 
-                    source.leadingComments = [
-                        {
-                            type: 'CommentBlock',
-                            value: ` ${[
-                                path.get('key').is('StringLiteral')
-                                    ? `webpackChunkName: "${
-                                          args[args.length - 1].value
-                                      }"`
-                                    : '',
-                                'webpackPrefetch: true',
-                            ]
-                                .filter(Boolean)
-                                .join(', ')} `,
-                        },
-                    ];
                     const argument = [
                         t.objectProperty(
                             t.identifier('promisedComponent'),


### PR DESCRIPTION
#### Reference issue: [129](https://github.com/trivago/melody/issues/129)

#### What changed in this PR:

Removes prefetch for asynchronously mounted components.

