### PR TITLE
Remove prefetch for async components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 - Do not log warning for component first emission in `melody-streams` in production [#128](https://github.com/trivago/melody/pull/128)
+- Removes prefetch for asynchronously mounted components [#129](https://github.com/trivago/melody/issues/129)
 
 ## 1.2.0
 

--- a/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/CompilerSpec.js.snap
@@ -1605,7 +1605,7 @@ _template.render = function (_context) {
     foo: \\"bar\\"
   });
   component(AsyncComponent, \\"bar\\", {
-    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"foo.twig\\"),
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\" */\\"foo.twig\\"),
     delayLoadingAnimation: 0,
     whileLoading: () => {
       text(\\" Loading... \\");
@@ -1620,7 +1620,7 @@ _template.render = function (_context) {
     }
   });
   component(AsyncComponent, \\"bar\\", {
-    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"foo.twig\\"),
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\" */\\"foo.twig\\"),
     delayLoadingAnimation: 500,
     whileLoading: () => {
       text(\\" Loading... \\");
@@ -1635,7 +1635,7 @@ _template.render = function (_context) {
     }
   });
   component(AsyncComponent, \\"bar\\", {
-    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"foo.twig\\"),
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\" */\\"foo.twig\\"),
     delayLoadingAnimation: 1000,
     whileLoading: () => {
       text(\\" Loading... \\");
@@ -1651,7 +1651,7 @@ _template.render = function (_context) {
     }
   });
   component(AsyncComponent, \\"\\" + (\\"bar-\\" + _context.part), {
-    promisedComponent: () => import( /* webpackPrefetch: true */\\"./parts/\\" + _context.part + \\".twig\\"),
+    promisedComponent: () => import( /*  */\\"./parts/\\" + _context.part + \\".twig\\"),
     delayLoadingAnimation: 1000,
     whileLoading: () => {
       text(\\" Loading... \\");
@@ -1666,7 +1666,7 @@ _template.render = function (_context) {
     }
   });
   component(AsyncComponent, \\"bar\\", {
-    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"./parts/\\" + _context.part + \\".twig\\"),
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\" */\\"./parts/\\" + _context.part + \\".twig\\"),
     delayLoadingAnimation: 1000,
     whileLoading: () => {
       text(\\" Loading... \\");
@@ -1677,7 +1677,7 @@ _template.render = function (_context) {
     }
   });
   component(AsyncComponent, \\"bar\\", {
-    promisedComponent: () => import( /* webpackChunkName: \\"bar\\", webpackPrefetch: true */\\"./parts/\\" + _context.part + \\".twig\\"),
+    promisedComponent: () => import( /* webpackChunkName: \\"bar\\" */\\"./parts/\\" + _context.part + \\".twig\\"),
     delayLoadingAnimation: 1000,
     whileLoading: () => {
       elementOpen(\\"strong\\", null, null);

--- a/packages/melody-plugin-idom/src/visitors/mount.js
+++ b/packages/melody-plugin-idom/src/visitors/mount.js
@@ -108,7 +108,6 @@ export default {
                 }
 
                 if (isAsync) {
-                    /* webpackPrefetch: true */
                     const source = path.node.source;
 
                     source.leadingComments = [
@@ -120,7 +119,6 @@ export default {
                                           args[args.length - 1].value
                                       }"`
                                     : '',
-                                'webpackPrefetch: true',
                             ]
                                 .filter(Boolean)
                                 .join(', ')} `,


### PR DESCRIPTION
#### Reference issue: [#129](https://github.com/trivago/melody/issues/129)

#### What changed in this PR:

Removes prefetch for asynchronously mounted components.
