### PR TITLE
Preserve HTML comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Features
 
--   `[melody-types]`, `[melody-parser]` The parser offers the option to preserve Twig comments in the AST
+-   `[melody-types]`, `[melody-parser]` The parser offers the option to preserve Twig comments in the AST (`ignoreTwigComments`)
+-   `[melody-types]`, `[melody-parser]` The parser offers the option to preserve HTML comments in the AST (`ignoreHtmlComments`)
 
 ## 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,32 @@
 ## master
 
+### Features
+
+-   `[melody-types]`, `[melody-parser]` The parser offers the option to preserve Twig comments in the AST
+
 ## 1.2.1
 
 ### Bug fixes
-- Do not log warning for component first emission in `melody-streams` in production [#128](https://github.com/trivago/melody/pull/128)
-- Removes webpack `prefetch` for asynchronously mounted components [#129](https://github.com/trivago/melody/issues/129)
+
+-   Do not log warning for component first emission in `melody-streams` in production [#128](https://github.com/trivago/melody/pull/128)
+-   Removes webpack `prefetch` for asynchronously mounted components [#129](https://github.com/trivago/melody/issues/129)
 
 ## 1.2.0
 
 ### Bug fixes
-- Fix melody-stream not rerendering in some cases [#112](https://github.com/trivago/melody/pull/112)
-- Warn about usage of non-breaking space [#107](https://github.com/trivago/melody/pull/107)
-- Fixed bindings of dispatchCustomEvent in `melody-streams` [#117](https://github.com/trivago/melody/pull/117)
-- Fixed `combineRefs` unsubscription in `melody-streams` [#120](https://github.com/trivago/melody/pull/120)
-- Melody sometimes removes classes from an element / element recycling without attributes [#118](https://github.com/trivago/melody/pull/118/files)
+
+-   Fix melody-stream not rerendering in some cases [#112](https://github.com/trivago/melody/pull/112)
+-   Warn about usage of non-breaking space [#107](https://github.com/trivago/melody/pull/107)
+-   Fixed bindings of dispatchCustomEvent in `melody-streams` [#117](https://github.com/trivago/melody/pull/117)
+-   Fixed `combineRefs` unsubscription in `melody-streams` [#120](https://github.com/trivago/melody/pull/120)
+-   Melody sometimes removes classes from an element / element recycling without attributes [#118](https://github.com/trivago/melody/pull/118/files)
 
 ### Chore & Maintenance
-- Removes `Chai` and `Sinon` support, Migrates tests to use `Jest`'s matchers. [#103](https://github.com/trivago/melody/pull/103)
-- Drop `bundledDependencies` option in package.json's to avoid issues with yarn [#113](https://github.com/trivago/melody/pull/113)
-- Add Github Actions for automation [#109](https://github.com/trivago/melody/pull/109)
-- Update various dependencies (lerna, babel-generate, etc.) [#95](https://github.com/trivago/melody/pull/95)
+
+-   Removes `Chai` and `Sinon` support, Migrates tests to use `Jest`'s matchers. [#103](https://github.com/trivago/melody/pull/103)
+-   Drop `bundledDependencies` option in package.json's to avoid issues with yarn [#113](https://github.com/trivago/melody/pull/113)
+-   Add Github Actions for automation [#109](https://github.com/trivago/melody/pull/109)
+-   Update various dependencies (lerna, babel-generate, etc.) [#95](https://github.com/trivago/melody/pull/95)
 
 ## 1.2.0-21.2 (beta)
 
@@ -27,109 +34,109 @@
 
 ### Features
 
-- Introduce `melody-streams` API [#102](https://github.com/trivago/melody/pull/102)
+-   Introduce `melody-streams` API [#102](https://github.com/trivago/melody/pull/102)
 
 ## 1.2.0-4 (beta)
 
 ### Features
 
-- Filter `trim`: add support for advanced features [#64](https://github.com/trivago/melody/pull/64)
-- Throw an error in `melody-redux`'s connect if no store found [#68](https://github.com/trivago/melody/pull/68)
-- Introduce `melody-hooks` API [#74](https://github.com/trivago/melody/pull/74)
-- `[melody-compiler]` warns on `mount` statement without `as` key [#48](https://github.com/trivago/melody/pull/48)
-- Introduce `useAtom` hook [#79](https://github.com/trivago/melody/pulls/79)
-- Introduce `useStore` hook and performance marks for hooks [#98](https://github.com/trivago/melody/pulls/98)
-- Added async mounting of components [#82](https://github.com/trivago/melody/pull/82)
+-   Filter `trim`: add support for advanced features [#64](https://github.com/trivago/melody/pull/64)
+-   Throw an error in `melody-redux`'s connect if no store found [#68](https://github.com/trivago/melody/pull/68)
+-   Introduce `melody-hooks` API [#74](https://github.com/trivago/melody/pull/74)
+-   `[melody-compiler]` warns on `mount` statement without `as` key [#48](https://github.com/trivago/melody/pull/48)
+-   Introduce `useAtom` hook [#79](https://github.com/trivago/melody/pulls/79)
+-   Introduce `useStore` hook and performance marks for hooks [#98](https://github.com/trivago/melody/pulls/98)
+-   Added async mounting of components [#82](https://github.com/trivago/melody/pull/82)
 
 ### Fixes
 
-- incorrect 'is' method call in melody-types [#20](https://github.com/trivago/melody/issues/20)
-- getFocusedPath can break on IE11 for svg elements [#57](https://github.com/trivago/melody/issues/57)
+-   incorrect 'is' method call in melody-types [#20](https://github.com/trivago/melody/issues/20)
+-   getFocusedPath can break on IE11 for svg elements [#57](https://github.com/trivago/melody/issues/57)
 
 ### Chore & Maintenance
 
-- Added PR template
-- Fix rollup config to generate esm properly [#42](https://github.com/trivago/melody/pull/42)
-- Added `testURL` in Jest config. [#49](https://github.com/trivago/melody/pull/49)
-- Migration to `babel-preset-env`. [#50](https://github.com/trivago/melody/issues/50)
-- Drops node 7 support `babel-preset-env`. [#55](https://github.com/trivago/melody/issues/55)
-- Adds node 10 support `babel-preset-env`. [#55](https://github.com/trivago/melody/issues/55)
-- Updates `bundlesize` dependency to `^0.15.2`, the latest release
-- Removes warnings during installation thrown by `lerna` and `npm`
-- Adds bundlesize token to travis config
-- Publishes packages for pushes to pull requests, based on the merge result
+-   Added PR template
+-   Fix rollup config to generate esm properly [#42](https://github.com/trivago/melody/pull/42)
+-   Added `testURL` in Jest config. [#49](https://github.com/trivago/melody/pull/49)
+-   Migration to `babel-preset-env`. [#50](https://github.com/trivago/melody/issues/50)
+-   Drops node 7 support `babel-preset-env`. [#55](https://github.com/trivago/melody/issues/55)
+-   Adds node 10 support `babel-preset-env`. [#55](https://github.com/trivago/melody/issues/55)
+-   Updates `bundlesize` dependency to `^0.15.2`, the latest release
+-   Removes warnings during installation thrown by `lerna` and `npm`
+-   Adds bundlesize token to travis config
+-   Publishes packages for pushes to pull requests, based on the merge result
 
 ## 1.1.0
 
 ### Features
 
-- `[melody-compiler]`, `[melody-loader]` added `melody-logger`
-- `[melody-idom]` added experimental synchronous deep rendering
-- Added `melody-plugin-load-functions`
-- Added `melody-plugin-skip-if`
+-   `[melody-compiler]`, `[melody-loader]` added `melody-logger`
+-   `[melody-idom]` added experimental synchronous deep rendering
+-   Added `melody-plugin-load-functions`
+-   Added `melody-plugin-skip-if`
 
 ### Fixes
 
-- Added transform-object-rest-spread plugin
-- `[melody-compiler]` remove `path.parse` dependency
-- Fixed typo in call date filter
-- Skip over all empty elements
+-   Added transform-object-rest-spread plugin
+-   `[melody-compiler]` remove `path.parse` dependency
+-   Fixed typo in call date filter
+-   Skip over all empty elements
 
 ### Chore & Maintenance
 
-- Fix ci with workflows and test on node 6 & 8
-- `[melody-runtime]` fix filter tests
+-   Fix ci with workflows and test on node 6 & 8
+-   `[melody-runtime]` fix filter tests
 
 ## 1.0.4
 
 ### Fixes
 
-- `[melody-idom]` revert commit [fdeef10](https://github.com/trivago/melody/commit/fdeef107bede824260916d458f956d3ee77d04e2): bugfix/remove-event-handlers
-- `[melody-jest-transform]` fixed peer dependencies
+-   `[melody-idom]` revert commit [fdeef10](https://github.com/trivago/melody/commit/fdeef107bede824260916d458f956d3ee77d04e2): bugfix/remove-event-handlers
+-   `[melody-jest-transform]` fixed peer dependencies
 
 ## 1.0.3
 
 ### Docs
 
-- Added dependancy installation steps to `README`
+-   Added dependancy installation steps to `README`
 
 ### Tests
 
-- `[melody-code-frame]` added unit tests
-- `[melody-jest-transform]` added unit tests
+-   `[melody-code-frame]` added unit tests
+-   `[melody-jest-transform]` added unit tests
 
 ### Fixes
 
-- Fixed `README` image
-- `[melody-idom]` remove event handlers
-- Compiler benchmark
-- `[melody-types]` added missing constant type
-- `[melody-runtime]` jest test cases with UTC timezone
-- `[melody-compiler]`, `[melody-parser]` fix not in operator
-- `[melody-idom]` draggable attribute to allow 'false' as value
+-   Fixed `README` image
+-   `[melody-idom]` remove event handlers
+-   Compiler benchmark
+-   `[melody-types]` added missing constant type
+-   `[melody-runtime]` jest test cases with UTC timezone
+-   `[melody-compiler]`, `[melody-parser]` fix not in operator
+-   `[melody-idom]` draggable attribute to allow 'false' as value
 
 ### Chore & Maintenance
 
-- Added bundle size status on `travis`
-- Added Community guidelines for github repository
-- Added Coveralls
+-   Added bundle size status on `travis`
+-   Added Community guidelines for github repository
+-   Added Coveralls
 
 ## 1.0.2
 
 ### Fixes
 
-- `[melody-idom]` ignore string refs if server-side rendered
+-   `[melody-idom]` ignore string refs if server-side rendered
 
 ## 1.0.1
 
 ### Features
 
-- Added package `neutrino-preset-melody`
+-   Added package `neutrino-preset-melody`
 
 ### Chore & Maintenance
 
-- Setup `travis`
+-   Setup `travis`
 
 ## <=1.0.1
 
-- See commit history for changes in previous versions of jest.
+-   See commit history for changes in previous versions of jest.

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -408,6 +408,16 @@ describe('Parser', function() {
             const node = parse`<input type="checkbox" checked>`;
             expect(node).toMatchSnapshot();
         });
+
+        it('should match HTML comments', function() {
+            const parser = createParserWithOptions('<span><!--//--></span>', {
+                ignoreWhitespace: false,
+                ignoreComments: false,
+                ignoreHtmlComments: false,
+            });
+            const node = parser.parse();
+            expect(node).toMatchSnapshot();
+        });
     });
 });
 

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -169,7 +169,9 @@ describe('Parser', function() {
 
     function createParserWithOptions(code, options) {
         const lexer = new Lexer(new CharStream(code));
-        return new Parser(new TokenStream(lexer, options));
+        return new Parser(new TokenStream(lexer, options), {
+            ignoreComments: options.ignoreComments,
+        });
     }
 
     describe('when parsing Twig comments', function() {

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -167,6 +167,23 @@ describe('Parser', function() {
         });
     });
 
+    function createParserWithOptions(code, options) {
+        const lexer = new Lexer(new CharStream(code));
+        return new Parser(new TokenStream(lexer, options));
+    }
+
+    describe('when parsing Twig comments', function() {
+        it('should match a comment', function() {
+            const parser = createParserWithOptions('{# This is a comment #}', {
+                ignoreWhitespace: false,
+                ignoreComments: false,
+                ignoreHtmlComments: false,
+            });
+            const node = parser.parse();
+            expect(node).toMatchSnapshot();
+        });
+    });
+
     describe('when parsing strings', function() {
         it('should match a string', function() {
             const node = parse`{{ "foo" }}`;
@@ -277,7 +294,7 @@ describe('Parser', function() {
                     expr = new n.BinaryExpression(
                         token.text,
                         expr,
-                        new n.Identifier(test.text),
+                        new n.Identifier(test.text)
                     );
                     if (not) {
                         expr = new n.UnaryExpression('not', expr);
@@ -294,8 +311,8 @@ describe('Parser', function() {
         it('should match tags', function() {
             const p = getParser(
                 getLexer(
-                    '{% if foo %}hello {{ adjective }} world{% else %}hello universe{% endif %}',
-                ),
+                    '{% if foo %}hello {{ adjective }} world{% else %}hello universe{% endif %}'
+                )
             );
             p.addTag({
                 name: 'if',
@@ -322,7 +339,7 @@ describe('Parser', function() {
                     return new n.ConditionalExpression(
                         test,
                         consequent,
-                        alternate,
+                        alternate
                     );
                 },
             });

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -12,6 +12,29 @@ exports[`Parser when parsing HTML should fail when parsing an opening expression
   1 | <div {{"
 `;
 
+exports[`Parser when parsing HTML should match HTML comments 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        Object {
+          "type": "HtmlComment",
+          "value": Object {
+            "type": "StringLiteral",
+            "value": "<!--//-->",
+          },
+        },
+      ],
+      "name": "span",
+      "selfClosing": false,
+      "type": "Element",
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
 exports[`Parser when parsing HTML should match a simple element 1`] = `
 Object {
   "expressions": Array [

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -278,6 +278,21 @@ Object {
 }
 `;
 
+exports[`Parser when parsing Twig comments should match a comment 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "type": "TwigComment",
+      "value": Object {
+        "type": "StringLiteral",
+        "value": "{# This is a comment #}",
+      },
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
 exports[`Parser when parsing array expressions should allow trailing commas 1`] = `
 Object {
   "expressions": Array [

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -46,7 +46,10 @@ const UNARY = Symbol(),
     TAG = Symbol(),
     TEST = Symbol();
 export default class Parser {
-    constructor(tokenStream, options = { ignoreComments: true }) {
+    constructor(
+        tokenStream,
+        options = { ignoreComments: true, ignoreHtmlComments: true }
+    ) {
         this.tokens = tokenStream;
         this[UNARY] = {};
         this[BINARY] = {};
@@ -153,6 +156,16 @@ export default class Parser {
                         );
                     }
                     break;
+                case Types.HTML_COMMENT:
+                    if (!this.options.ignoreHtmlComments) {
+                        p.add(
+                            createNode(
+                                n.HtmlComment,
+                                token,
+                                createNode(n.StringLiteral, token, token.text)
+                            )
+                        );
+                    }
             }
         }
         return p;

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -141,6 +141,15 @@ export default class Parser {
                 case Types.ELEMENT_START:
                     p.add(this.matchElement());
                     break;
+                case Types.COMMENT:
+                    p.add(
+                        createNode(
+                            n.TwigComment,
+                            token,
+                            createNode(n.StringLiteral, token, token.text)
+                        )
+                    );
+                    break;
             }
         }
         return p;

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -46,12 +46,13 @@ const UNARY = Symbol(),
     TAG = Symbol(),
     TEST = Symbol();
 export default class Parser {
-    constructor(tokenStream) {
+    constructor(tokenStream, options = { ignoreComments: true }) {
         this.tokens = tokenStream;
         this[UNARY] = {};
         this[BINARY] = {};
         this[TAG] = {};
         this[TEST] = {};
+        this.options = options;
     }
 
     addUnaryOperator(op: UnaryOperator) {
@@ -142,13 +143,15 @@ export default class Parser {
                     p.add(this.matchElement());
                     break;
                 case Types.COMMENT:
-                    p.add(
-                        createNode(
-                            n.TwigComment,
-                            token,
-                            createNode(n.StringLiteral, token, token.text)
-                        )
-                    );
+                    if (!this.options.ignoreComments) {
+                        p.add(
+                            createNode(
+                                n.TwigComment,
+                                token,
+                                createNode(n.StringLiteral, token, token.text)
+                            )
+                        );
+                    }
                     break;
             }
         }

--- a/packages/melody-types/src/index.js
+++ b/packages/melody-types/src/index.js
@@ -358,3 +358,12 @@ export class Attribute extends Node {
 }
 type(Attribute, 'Attribute');
 visitor(Attribute, 'name', 'value');
+
+export class TwigComment extends Node {
+    constructor(text: StringLiteral) {
+        super();
+        this.value = text;
+    }
+}
+type(TwigComment, 'TwigComment');
+visitor(TwigComment, 'value');

--- a/packages/melody-types/src/index.js
+++ b/packages/melody-types/src/index.js
@@ -367,3 +367,12 @@ export class TwigComment extends Node {
 }
 type(TwigComment, 'TwigComment');
 visitor(TwigComment, 'value');
+
+export class HtmlComment extends Node {
+    constructor(text: StringLiteral) {
+        super();
+        this.value = text;
+    }
+}
+type(HtmlComment, 'HtmlComment');
+visitor(HtmlComment, 'value');


### PR DESCRIPTION
#### What changed in this PR:

This PR adds a new option "preserveHtmlComments" to the Parser constructor. It defaults to `false`, which matches the standard behaviour of the parser so far.

If set to `true`, however, HTML comments will be preserved in the AST, using the new node type `HtmlComment`.

