### PR TITLE
Optionally skip whitespace trimming in tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## master
 
+## 1.3.1
+
+### Features
+
+-   `[melody-parser]` Tokenizer optionally preserves whitespace (e.g., around Twig comments)
+
 ## 1.3.0
 
 ### Features

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -178,8 +178,21 @@ describe('Parser', function() {
         it('should match a comment', function() {
             const parser = createParserWithOptions('{# This is a comment #}', {
                 ignoreComments: false,
-                ignoreHtmlComments: false,
             });
+            const node = parser.parse();
+            expect(node).toMatchSnapshot();
+        });
+
+        it('should preserve whitespace between comments', function() {
+            const parser = createParserWithOptions(
+                `{# First comment #}
+            
+            {# Second comment #}`,
+                {
+                    ignoreComments: false,
+                    ignoreWhitespace: false,
+                }
+            );
             const node = parser.parse();
             expect(node).toMatchSnapshot();
         });

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -339,6 +339,37 @@ Object {
 }
 `;
 
+exports[`Parser when parsing Twig comments should preserve whitespace between comments 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "type": "TwigComment",
+      "value": Object {
+        "type": "StringLiteral",
+        "value": "{# First comment #}",
+      },
+    },
+    Object {
+      "type": "PrintTextStatement",
+      "value": Object {
+        "type": "StringLiteral",
+        "value": "
+            
+            ",
+      },
+    },
+    Object {
+      "type": "TwigComment",
+      "value": Object {
+        "type": "StringLiteral",
+        "value": "{# Second comment #}",
+      },
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
 exports[`Parser when parsing array expressions should allow trailing commas 1`] = `
 Object {
   "expressions": Array [

--- a/packages/melody-parser/src/TokenStream.js
+++ b/packages/melody-parser/src/TokenStream.js
@@ -168,7 +168,7 @@ function getAllTokens(lexer, options) {
         ) {
             tokens[tokens.length] = token;
         }
-        acceptWhitespaceControl = true && options.ignoreWhitespace;
+        acceptWhitespaceControl = options.ignoreWhitespace;
         if (token.type === ERROR) {
             return tokens;
         }

--- a/packages/melody-parser/src/TokenStream.js
+++ b/packages/melody-parser/src/TokenStream.js
@@ -168,7 +168,7 @@ function getAllTokens(lexer, options) {
         ) {
             tokens[tokens.length] = token;
         }
-        acceptWhitespaceControl = true;
+        acceptWhitespaceControl = true && options.ignoreWhitespace;
         if (token.type === ERROR) {
             return tokens;
         }


### PR DESCRIPTION
#### What changed in this PR:

TokenStream, by default, optimizes some whitespace away (e.g., around Twig comments), no matter whether `ignoreWhitespace` is set or not. This PR skips this whitespace trimming when `ignoreWhitespace` is set to `false`. 

A test and a tiny bit of boyscouting is added, too.

