### PR TITLE
Tokenizer preserve whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 -   `[melody-parser]` Tokenizer preserves whitespace (e.g., around Twig comments) when option `applyWhitespaceTrimming` is set to `false`
+-   `[melody-parser]` Expressions can have the `trimLeft` and `trimRight` flag to account for `{{-` and `-}}`, respectively.
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
--   `[melody-parser]` Tokenizer optionally preserves whitespace (e.g., around Twig comments)
+-   `[melody-parser]` Tokenizer preserves whitespace (e.g., around Twig comments) when option `applyWhitespaceTrimming` is set to `false`
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## master
 
+## 1.3.1
+
+### Features
+
+-   `[melody-parser]` Tokenizer optionally preserves whitespace (e.g., around Twig comments)
+
 ## 1.3.0
 
 ### Features

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -178,8 +178,21 @@ describe('Parser', function() {
         it('should match a comment', function() {
             const parser = createParserWithOptions('{# This is a comment #}', {
                 ignoreComments: false,
-                ignoreHtmlComments: false,
             });
+            const node = parser.parse();
+            expect(node).toMatchSnapshot();
+        });
+
+        it('should preserve whitespace between comments', function() {
+            const parser = createParserWithOptions(
+                `{# First comment #}
+            
+            {# Second comment #}`,
+                {
+                    ignoreComments: false,
+                    ignoreWhitespace: false,
+                }
+            );
             const node = parser.parse();
             expect(node).toMatchSnapshot();
         });

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -169,9 +169,7 @@ describe('Parser', function() {
 
     function createParserWithOptions(code, options) {
         const lexer = new Lexer(new CharStream(code));
-        return new Parser(new TokenStream(lexer, options), {
-            ignoreComments: options.ignoreComments,
-        });
+        return new Parser(new TokenStream(lexer, options), options);
     }
 
     describe('when parsing Twig comments', function() {
@@ -190,7 +188,7 @@ describe('Parser', function() {
             {# Second comment #}`,
                 {
                     ignoreComments: false,
-                    ignoreWhitespace: false,
+                    applyWhitespaceTrimming: false,
                 }
             );
             const node = parser.parse();
@@ -430,10 +428,21 @@ describe('Parser', function() {
             expect(node).toMatchSnapshot();
         });
 
-        it('should match character entities', function() {
+        it('should respect the decodeEntities option', function() {
             const parser = createParserWithOptions('<span>&#8206;</span>', {
                 decodeEntites: false,
             });
+            const node = parser.parse();
+            expect(node).toMatchSnapshot();
+        });
+
+        it('should respect applyWhitespaceTrimming setting', function() {
+            const parser = createParserWithOptions(
+                '<span title="Testing: {{- noWhitespaceTest -}} foo">Test</span>',
+                {
+                    applyWhitespaceTrimming: false,
+                }
+            );
             const node = parser.parse();
             expect(node).toMatchSnapshot();
         });

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -147,29 +147,6 @@ Object {
 }
 `;
 
-exports[`Parser when parsing HTML should match character entities 1`] = `
-Object {
-  "expressions": Array [
-    Object {
-      "attributes": Array [],
-      "children": Array [
-        Object {
-          "type": "PrintTextStatement",
-          "value": Object {
-            "type": "StringLiteral",
-            "value": "&#8206;",
-          },
-        },
-      ],
-      "name": "span",
-      "selfClosing": false,
-      "type": "Element",
-    },
-  ],
-  "type": "SequenceExpression",
-}
-`;
-
 exports[`Parser when parsing HTML should match expression arguments 1`] = `
 Object {
   "expressions": Array [
@@ -317,6 +294,80 @@ Object {
       "children": Array [],
       "name": "input",
       "selfClosing": true,
+      "type": "Element",
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
+exports[`Parser when parsing HTML should respect applyWhitespaceTrimming setting 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "attributes": Array [
+        Object {
+          "name": Object {
+            "name": "title",
+            "type": "Identifier",
+          },
+          "type": "Attribute",
+          "value": Object {
+            "left": Object {
+              "left": Object {
+                "type": "StringLiteral",
+                "value": "Testing: ",
+              },
+              "operator": "~",
+              "right": Object {
+                "name": "noWhitespaceTest",
+                "type": "Identifier",
+              },
+              "type": "BinaryConcatExpression",
+            },
+            "operator": "~",
+            "right": Object {
+              "type": "StringLiteral",
+              "value": " foo",
+            },
+            "type": "BinaryConcatExpression",
+          },
+        },
+      ],
+      "children": Array [
+        Object {
+          "type": "PrintTextStatement",
+          "value": Object {
+            "type": "StringLiteral",
+            "value": "Test",
+          },
+        },
+      ],
+      "name": "span",
+      "selfClosing": false,
+      "type": "Element",
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
+exports[`Parser when parsing HTML should respect the decodeEntities option 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        Object {
+          "type": "PrintTextStatement",
+          "value": Object {
+            "type": "StringLiteral",
+            "value": "&#8206;",
+          },
+        },
+      ],
+      "name": "span",
+      "selfClosing": false,
       "type": "Element",
     },
   ],

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -70,6 +70,8 @@ Object {
           },
           "type": "Attribute",
           "value": Object {
+            "exprEndAfter": true,
+            "exprStartBefore": true,
             "name": "id",
             "type": "Identifier",
           },
@@ -111,6 +113,8 @@ Object {
             },
             "operator": "~",
             "right": Object {
+              "exprEndAfter": true,
+              "exprStartBefore": true,
               "name": "bar",
               "type": "Identifier",
             },
@@ -124,6 +128,8 @@ Object {
           },
           "type": "Attribute",
           "value": Object {
+            "exprEndAfter": true,
+            "exprStartBefore": true,
             "name": "id",
             "type": "Identifier",
           },
@@ -153,6 +159,8 @@ Object {
     Object {
       "attributes": Array [
         Object {
+          "exprEndAfter": true,
+          "exprStartBefore": true,
           "name": "attributes",
           "type": "Identifier",
         },
@@ -185,6 +193,8 @@ Object {
             },
             "operator": "~",
             "right": Object {
+              "exprEndAfter": true,
+              "exprStartBefore": true,
               "name": "bar",
               "type": "Identifier",
             },
@@ -198,6 +208,8 @@ Object {
           },
           "type": "Attribute",
           "value": Object {
+            "exprEndAfter": true,
+            "exprStartBefore": true,
             "name": "id",
             "type": "Identifier",
           },
@@ -320,7 +332,11 @@ Object {
               },
               "operator": "~",
               "right": Object {
+                "exprEndAfter": true,
+                "exprStartBefore": true,
                 "name": "noWhitespaceTest",
+                "trimLeft": true,
+                "trimRight": true,
                 "type": "Identifier",
               },
               "type": "BinaryConcatExpression",
@@ -437,6 +453,8 @@ Object {
             "type": "Identifier",
           },
         ],
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "type": "ArrayExpression",
       },
     },
@@ -452,6 +470,8 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "object": Object {
           "name": "hello",
           "type": "Identifier",
@@ -492,6 +512,8 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "object": Object {
           "name": "hello",
           "type": "Identifier",
@@ -515,6 +537,8 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "object": Object {
           "name": "hello",
           "type": "Identifier",
@@ -538,6 +562,8 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "object": Object {
           "name": "hello",
           "type": "Identifier",
@@ -561,6 +587,7 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "alternate": Object {
+          "exprEndAfter": true,
           "name": "bar",
           "type": "Identifier",
         },
@@ -568,6 +595,7 @@ Object {
           "name": "foo",
           "type": "Identifier",
         },
+        "exprStartBefore": true,
         "test": Object {
           "name": "test",
           "type": "Identifier",
@@ -587,6 +615,7 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "alternate": Object {
+          "exprEndAfter": true,
           "type": "StringLiteral",
           "value": "",
         },
@@ -594,6 +623,7 @@ Object {
           "name": "foo",
           "type": "Identifier",
         },
+        "exprStartBefore": true,
         "test": Object {
           "name": "test",
           "type": "Identifier",
@@ -613,10 +643,12 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "alternate": Object {
+          "exprEndAfter": true,
           "name": "bar",
           "type": "Identifier",
         },
         "consequent": null,
+        "exprStartBefore": true,
         "test": Object {
           "name": "test",
           "type": "Identifier",
@@ -637,9 +669,11 @@ Object {
       "value": Object {
         "alternate": null,
         "consequent": Object {
+          "exprEndAfter": true,
           "name": "foo",
           "type": "Identifier",
         },
+        "exprStartBefore": true,
         "test": Object {
           "name": "test",
           "type": "Identifier",
@@ -658,6 +692,8 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "name": "hello",
         "type": "Identifier",
       },
@@ -674,6 +710,7 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "alternate": Object {
+          "exprEndAfter": true,
           "type": "BooleanLiteral",
           "value": true,
         },
@@ -681,6 +718,7 @@ Object {
           "type": "BooleanLiteral",
           "value": false,
         },
+        "exprStartBefore": true,
         "test": Object {
           "arguments": Array [
             Object {
@@ -713,6 +751,8 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "object": Object {
           "name": "foo",
           "type": "Identifier",
@@ -745,6 +785,8 @@ Object {
             "value": 3,
           },
         ],
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "name": Object {
           "name": "slice",
           "type": "Identifier",
@@ -768,6 +810,8 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "arguments": Array [],
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "name": Object {
           "name": "foo",
           "type": "Identifier",
@@ -791,6 +835,8 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "arguments": Array [],
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "name": Object {
           "name": "raw",
           "type": "Identifier",
@@ -835,6 +881,8 @@ Object {
           "name": "hello",
           "type": "Identifier",
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "type": "CallExpression",
       },
     },
@@ -905,6 +953,8 @@ Object {
           "name": "hello",
           "type": "Identifier",
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "type": "CallExpression",
       },
     },
@@ -936,6 +986,8 @@ Object {
           "name": "hello",
           "type": "Identifier",
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "type": "CallExpression",
       },
     },
@@ -950,6 +1002,8 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "properties": Array [
           Object {
             "computed": false,
@@ -1022,12 +1076,15 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "left": Object {
           "name": "foo",
           "type": "Identifier",
         },
         "operator": "in",
         "right": Object {
+          "exprEndAfter": true,
           "name": "bar",
           "type": "Identifier",
         },
@@ -1046,17 +1103,21 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "argument": Object {
+          "exprEndAfter": true,
           "left": Object {
             "name": "foo",
             "type": "Identifier",
           },
           "operator": "in",
           "right": Object {
+            "exprEndAfter": true,
             "name": "bar",
             "type": "Identifier",
           },
           "type": "BinaryExpression",
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "operator": "not",
         "type": "UnaryExpression",
       },
@@ -1084,6 +1145,8 @@ Object {
           },
           "type": "BinaryExpression",
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "operator": "not",
         "type": "UnaryExpression",
       },
@@ -1100,9 +1163,12 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "argument": Object {
+          "exprEndAfter": true,
           "name": "foo",
           "type": "Identifier",
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "operator": "not",
         "type": "UnaryExpression",
       },
@@ -1122,6 +1188,8 @@ Object {
           "type": "NumericLiteral",
           "value": 5,
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "start": Object {
           "type": "NumericLiteral",
           "value": 3,
@@ -1145,6 +1213,8 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "end": null,
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "start": Object {
           "type": "NumericLiteral",
           "value": 2,
@@ -1171,6 +1241,8 @@ Object {
           "type": "NumericLiteral",
           "value": 2,
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "start": null,
         "target": Object {
           "name": "foo",
@@ -1194,6 +1266,8 @@ Object {
           "type": "NumericLiteral",
           "value": 5,
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "start": Object {
           "type": "NumericLiteral",
           "value": 3,
@@ -1236,6 +1310,8 @@ Object {
           },
           "type": "MemberExpression",
         },
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "start": Object {
           "computed": false,
           "object": Object {
@@ -1266,6 +1342,8 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "left": Object {
           "left": Object {
             "type": "StringLiteral",
@@ -1297,6 +1375,8 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "type": "StringLiteral",
         "value": "foo",
       },
@@ -1312,6 +1392,8 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
+        "exprEndAfter": true,
+        "exprStartBefore": true,
         "left": Object {
           "type": "StringLiteral",
           "value": "foo ",
@@ -1401,6 +1483,8 @@ Object {
           Object {
             "type": "PrintExpressionStatement",
             "value": Object {
+              "exprEndAfter": true,
+              "exprStartBefore": true,
               "name": "adjective",
               "type": "Identifier",
             },

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -70,8 +70,6 @@ Object {
           },
           "type": "Attribute",
           "value": Object {
-            "exprEndAfter": true,
-            "exprStartBefore": true,
             "name": "id",
             "type": "Identifier",
           },
@@ -113,8 +111,6 @@ Object {
             },
             "operator": "~",
             "right": Object {
-              "exprEndAfter": true,
-              "exprStartBefore": true,
               "name": "bar",
               "type": "Identifier",
             },
@@ -128,8 +124,6 @@ Object {
           },
           "type": "Attribute",
           "value": Object {
-            "exprEndAfter": true,
-            "exprStartBefore": true,
             "name": "id",
             "type": "Identifier",
           },
@@ -159,8 +153,6 @@ Object {
     Object {
       "attributes": Array [
         Object {
-          "exprEndAfter": true,
-          "exprStartBefore": true,
           "name": "attributes",
           "type": "Identifier",
         },
@@ -193,8 +185,6 @@ Object {
             },
             "operator": "~",
             "right": Object {
-              "exprEndAfter": true,
-              "exprStartBefore": true,
               "name": "bar",
               "type": "Identifier",
             },
@@ -208,8 +198,6 @@ Object {
           },
           "type": "Attribute",
           "value": Object {
-            "exprEndAfter": true,
-            "exprStartBefore": true,
             "name": "id",
             "type": "Identifier",
           },
@@ -332,8 +320,6 @@ Object {
               },
               "operator": "~",
               "right": Object {
-                "exprEndAfter": true,
-                "exprStartBefore": true,
                 "name": "noWhitespaceTest",
                 "trimLeft": true,
                 "trimRight": true,
@@ -453,8 +439,6 @@ Object {
             "type": "Identifier",
           },
         ],
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "type": "ArrayExpression",
       },
     },
@@ -470,8 +454,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "object": Object {
           "name": "hello",
           "type": "Identifier",
@@ -512,8 +494,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "object": Object {
           "name": "hello",
           "type": "Identifier",
@@ -537,8 +517,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "object": Object {
           "name": "hello",
           "type": "Identifier",
@@ -562,8 +540,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "object": Object {
           "name": "hello",
           "type": "Identifier",
@@ -587,7 +563,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "alternate": Object {
-          "exprEndAfter": true,
           "name": "bar",
           "type": "Identifier",
         },
@@ -595,7 +570,6 @@ Object {
           "name": "foo",
           "type": "Identifier",
         },
-        "exprStartBefore": true,
         "test": Object {
           "name": "test",
           "type": "Identifier",
@@ -615,7 +589,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "alternate": Object {
-          "exprEndAfter": true,
           "type": "StringLiteral",
           "value": "",
         },
@@ -623,7 +596,6 @@ Object {
           "name": "foo",
           "type": "Identifier",
         },
-        "exprStartBefore": true,
         "test": Object {
           "name": "test",
           "type": "Identifier",
@@ -643,12 +615,10 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "alternate": Object {
-          "exprEndAfter": true,
           "name": "bar",
           "type": "Identifier",
         },
         "consequent": null,
-        "exprStartBefore": true,
         "test": Object {
           "name": "test",
           "type": "Identifier",
@@ -669,11 +639,9 @@ Object {
       "value": Object {
         "alternate": null,
         "consequent": Object {
-          "exprEndAfter": true,
           "name": "foo",
           "type": "Identifier",
         },
-        "exprStartBefore": true,
         "test": Object {
           "name": "test",
           "type": "Identifier",
@@ -692,8 +660,6 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "name": "hello",
         "type": "Identifier",
       },
@@ -710,7 +676,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "alternate": Object {
-          "exprEndAfter": true,
           "type": "BooleanLiteral",
           "value": true,
         },
@@ -718,7 +683,6 @@ Object {
           "type": "BooleanLiteral",
           "value": false,
         },
-        "exprStartBefore": true,
         "test": Object {
           "arguments": Array [
             Object {
@@ -751,8 +715,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "computed": true,
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "object": Object {
           "name": "foo",
           "type": "Identifier",
@@ -785,8 +747,6 @@ Object {
             "value": 3,
           },
         ],
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "name": Object {
           "name": "slice",
           "type": "Identifier",
@@ -810,8 +770,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "arguments": Array [],
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "name": Object {
           "name": "foo",
           "type": "Identifier",
@@ -835,8 +793,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "arguments": Array [],
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "name": Object {
           "name": "raw",
           "type": "Identifier",
@@ -881,8 +837,6 @@ Object {
           "name": "hello",
           "type": "Identifier",
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "type": "CallExpression",
       },
     },
@@ -953,8 +907,6 @@ Object {
           "name": "hello",
           "type": "Identifier",
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "type": "CallExpression",
       },
     },
@@ -986,8 +938,6 @@ Object {
           "name": "hello",
           "type": "Identifier",
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "type": "CallExpression",
       },
     },
@@ -1002,8 +952,6 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "properties": Array [
           Object {
             "computed": false,
@@ -1076,15 +1024,12 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "left": Object {
           "name": "foo",
           "type": "Identifier",
         },
         "operator": "in",
         "right": Object {
-          "exprEndAfter": true,
           "name": "bar",
           "type": "Identifier",
         },
@@ -1103,21 +1048,17 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "argument": Object {
-          "exprEndAfter": true,
           "left": Object {
             "name": "foo",
             "type": "Identifier",
           },
           "operator": "in",
           "right": Object {
-            "exprEndAfter": true,
             "name": "bar",
             "type": "Identifier",
           },
           "type": "BinaryExpression",
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "operator": "not",
         "type": "UnaryExpression",
       },
@@ -1145,8 +1086,6 @@ Object {
           },
           "type": "BinaryExpression",
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "operator": "not",
         "type": "UnaryExpression",
       },
@@ -1163,12 +1102,9 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "argument": Object {
-          "exprEndAfter": true,
           "name": "foo",
           "type": "Identifier",
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "operator": "not",
         "type": "UnaryExpression",
       },
@@ -1188,8 +1124,6 @@ Object {
           "type": "NumericLiteral",
           "value": 5,
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "start": Object {
           "type": "NumericLiteral",
           "value": 3,
@@ -1213,8 +1147,6 @@ Object {
       "type": "PrintExpressionStatement",
       "value": Object {
         "end": null,
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "start": Object {
           "type": "NumericLiteral",
           "value": 2,
@@ -1241,8 +1173,6 @@ Object {
           "type": "NumericLiteral",
           "value": 2,
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "start": null,
         "target": Object {
           "name": "foo",
@@ -1266,8 +1196,6 @@ Object {
           "type": "NumericLiteral",
           "value": 5,
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "start": Object {
           "type": "NumericLiteral",
           "value": 3,
@@ -1310,8 +1238,6 @@ Object {
           },
           "type": "MemberExpression",
         },
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "start": Object {
           "computed": false,
           "object": Object {
@@ -1342,8 +1268,6 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "left": Object {
           "left": Object {
             "type": "StringLiteral",
@@ -1375,8 +1299,6 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "type": "StringLiteral",
         "value": "foo",
       },
@@ -1392,8 +1314,6 @@ Object {
     Object {
       "type": "PrintExpressionStatement",
       "value": Object {
-        "exprEndAfter": true,
-        "exprStartBefore": true,
         "left": Object {
           "type": "StringLiteral",
           "value": "foo ",
@@ -1483,8 +1403,6 @@ Object {
           Object {
             "type": "PrintExpressionStatement",
             "value": Object {
-              "exprEndAfter": true,
-              "exprStartBefore": true,
               "name": "adjective",
               "type": "Identifier",
             },

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -339,6 +339,37 @@ Object {
 }
 `;
 
+exports[`Parser when parsing Twig comments should preserve whitespace between comments 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "type": "TwigComment",
+      "value": Object {
+        "type": "StringLiteral",
+        "value": "{# First comment #}",
+      },
+    },
+    Object {
+      "type": "PrintTextStatement",
+      "value": Object {
+        "type": "StringLiteral",
+        "value": "
+            
+            ",
+      },
+    },
+    Object {
+      "type": "TwigComment",
+      "value": Object {
+        "type": "StringLiteral",
+        "value": "{# Second comment #}",
+      },
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
 exports[`Parser when parsing array expressions should allow trailing commas 1`] = `
 Object {
   "expressions": Array [

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -338,15 +338,14 @@ export default class Parser {
         const tokens = this.tokens;
         let token,
             op,
-            trimLeft = false,
-            exprStartBefore = false;
+            trimLeft = false;
 
         // Check for {{- (trim preceding whitespace)
-        if (tokens.la(-1).type === Types.EXPRESSION_START) {
-            exprStartBefore = true;
-            if (tokens.la(-1).text.endsWith('-')) {
-                trimLeft = true;
-            }
+        if (
+            tokens.la(-1).type === Types.EXPRESSION_START &&
+            tokens.la(-1).text.endsWith('-')
+        ) {
+            trimLeft = true;
         }
 
         let expr = this.getPrimary();
@@ -374,17 +373,11 @@ export default class Parser {
             precedence === 0 ? this.matchConditionalExpression(expr) : expr;
 
         // Check for -}} (trim following whitespace)
-        if (token.type === Types.EXPRESSION_END) {
-            result.exprEndAfter = true;
-            if (token.text.startsWith('-')) {
-                result.trimRight = true;
-            }
+        if (token.type === Types.EXPRESSION_END && token.text.startsWith('-')) {
+            result.trimRight = true;
         }
         if (trimLeft) {
             result.trimLeft = trimLeft;
-        }
-        if (exprStartBefore) {
-            result.exprStartBefore = exprStartBefore;
         }
 
         return result;

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -46,20 +46,21 @@ const UNARY = Symbol(),
     TAG = Symbol(),
     TEST = Symbol();
 export default class Parser {
-    constructor(
-        tokenStream,
-        options = {
-            ignoreComments: true,
-            ignoreHtmlComments: true,
-            decodeEntites: true,
-        }
-    ) {
+    constructor(tokenStream, options) {
         this.tokens = tokenStream;
         this[UNARY] = {};
         this[BINARY] = {};
         this[TAG] = {};
         this[TEST] = {};
-        this.options = options;
+        this.options = Object.assign(
+            {},
+            {
+                ignoreComments: true,
+                ignoreHtmlComments: true,
+                decodeEntites: true,
+            },
+            options
+        );
     }
 
     addUnaryOperator(op: UnaryOperator) {

--- a/packages/melody-parser/src/TokenStream.js
+++ b/packages/melody-parser/src/TokenStream.js
@@ -168,7 +168,7 @@ function getAllTokens(lexer, options) {
         ) {
             tokens[tokens.length] = token;
         }
-        acceptWhitespaceControl = true && options.ignoreWhitespace;
+        acceptWhitespaceControl = options.ignoreWhitespace;
         if (token.type === ERROR) {
             return tokens;
         }

--- a/packages/melody-parser/src/TokenStream.js
+++ b/packages/melody-parser/src/TokenStream.js
@@ -35,13 +35,19 @@ const TOKENS = Symbol(),
     LENGTH = Symbol();
 
 export default class TokenStream {
-    constructor(
-        lexer,
-        options = { ignoreComments: true, ignoreWhitespace: true }
-    ) {
+    constructor(lexer, options) {
         this.input = lexer;
         this.index = 0;
-        this.options = options;
+        options = Object.assign(
+            {},
+            {
+                ignoreComments: true,
+                ignoreHtmlComments: true,
+                ignoreWhitespace: true,
+                applyWhitespaceTrimming: true,
+            },
+            options
+        );
         this[TOKENS] = getAllTokens(lexer, options);
         this[LENGTH] = this[TOKENS].length;
 
@@ -168,7 +174,7 @@ function getAllTokens(lexer, options) {
         ) {
             tokens[tokens.length] = token;
         }
-        acceptWhitespaceControl = options.ignoreWhitespace;
+        acceptWhitespaceControl = options.applyWhitespaceTrimming;
         if (token.type === ERROR) {
             return tokens;
         }

--- a/packages/melody-parser/src/TokenStream.js
+++ b/packages/melody-parser/src/TokenStream.js
@@ -38,7 +38,7 @@ export default class TokenStream {
     constructor(lexer, options) {
         this.input = lexer;
         this.index = 0;
-        options = Object.assign(
+        const mergedOptions = Object.assign(
             {},
             {
                 ignoreComments: true,
@@ -48,7 +48,7 @@ export default class TokenStream {
             },
             options
         );
-        this[TOKENS] = getAllTokens(lexer, options);
+        this[TOKENS] = getAllTokens(lexer, mergedOptions);
         this[LENGTH] = this[TOKENS].length;
 
         if (

--- a/packages/melody-parser/src/TokenStream.js
+++ b/packages/melody-parser/src/TokenStream.js
@@ -168,7 +168,7 @@ function getAllTokens(lexer, options) {
         ) {
             tokens[tokens.length] = token;
         }
-        acceptWhitespaceControl = true;
+        acceptWhitespaceControl = true && options.ignoreWhitespace;
         if (token.type === ERROR) {
             return tokens;
         }


### PR DESCRIPTION
#### What changed in this PR:

- Add a new option `applyWhitespaceTrimming` to `TokenStream`. There was already `ignoreWhitespace`, which means that no tokens of type "whitespace" are emitted. However, whitespace trimming is mainly about Twig's handling of the `-` character in expressions like  `{{- ... -}}`, which trims trailing and leading whitespace in surrounding text nodes. Usually, you want this, so this setting defaults to `true`. However, for pretty printing, this should not be applied.
- Improve option handling in `Parser` and `TokenStream`. Previously, if you passed only one option (say, `{ ignoreWhitespace: true}`), the remaining options would be undefined instead of set to the default values defined in the constructor. Might be a Rollup setting. This PR guarantees the defaults are respected by using `Object.assign()`.
- Add flags to expression nodes: trimLeft, trimRight. These can be helpful for pretty printing.
