### PR TITLE
Fix typo bug: "decodeEntites" vs. "decodeEntities"

### DIFF
--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -430,7 +430,7 @@ describe('Parser', function() {
 
         it('should respect the decodeEntities option', function() {
             const parser = createParserWithOptions('<span>&#8206;</span>', {
-                decodeEntites: false,
+                decodeEntities: false,
             });
             const node = parser.parse();
             expect(node).toMatchSnapshot();

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -57,7 +57,7 @@ export default class Parser {
             {
                 ignoreComments: true,
                 ignoreHtmlComments: true,
-                decodeEntites: true,
+                decodeEntities: true,
             },
             options
         );
@@ -142,7 +142,7 @@ export default class Parser {
                             createNode(
                                 n.StringLiteral,
                                 token,
-                                this.options.decodeEntites
+                                this.options.decodeEntities
                                     ? he.decode(token.text)
                                     : token.text
                             )


### PR DESCRIPTION
#### What changed in this PR:

This PR fixes a typo bug that has sneaked into the last release: The parser option `decodeEntites` should, of course, have been named `decodeEntities` (missing `i` in the former).

Code and tests have been updated accordingly.

