### PR TITLE
Make Lexer interrupt text token when hitting an HTML comment

### DIFF
--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -428,6 +428,20 @@ describe('Parser', function() {
             expect(node).toMatchSnapshot();
         });
 
+        it('should match HTML comments mixed with other text', function() {
+            const markup = `<span>
+            First some text
+            
+            <!-- Then a comment-->
+            </span>`;
+            const parser = createParserWithOptions(markup, {
+                ignoreComments: false,
+                ignoreHtmlComments: false,
+            });
+            const node = parser.parse();
+            expect(node).toMatchSnapshot();
+        });
+
         it('should respect the decodeEntities option', function() {
             const parser = createParserWithOptions('<span>&#8206;</span>', {
                 decodeEntities: false,

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -35,6 +35,47 @@ Object {
 }
 `;
 
+exports[`Parser when parsing HTML should match HTML comments mixed with other text 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "attributes": Array [],
+      "children": Array [
+        Object {
+          "type": "PrintTextStatement",
+          "value": Object {
+            "type": "StringLiteral",
+            "value": "
+            First some text
+            
+            ",
+          },
+        },
+        Object {
+          "type": "HtmlComment",
+          "value": Object {
+            "type": "StringLiteral",
+            "value": "<!-- Then a comment-->",
+          },
+        },
+        Object {
+          "type": "PrintTextStatement",
+          "value": Object {
+            "type": "StringLiteral",
+            "value": "
+            ",
+          },
+        },
+      ],
+      "name": "span",
+      "selfClosing": false,
+      "type": "Element",
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
 exports[`Parser when parsing HTML should match a simple element 1`] = `
 Object {
   "expressions": Array [

--- a/packages/melody-parser/src/Lexer.js
+++ b/packages/melody-parser/src/Lexer.js
@@ -573,7 +573,12 @@ export default class Lexer {
                     break;
                 }
             } else if (c === '<') {
-                if (input.la(1) === '/' || isAlpha(input.lac(1))) {
+                const nextChar = input.la(1);
+                if (
+                    nextChar === '/' || // closing tag
+                    nextChar === '!' || // HTML comment
+                    isAlpha(input.lac(1)) // opening tag
+                ) {
                     break;
                 } else if (input.la(1) === '{') {
                     const c2 = input.la(1);


### PR DESCRIPTION
Previously, in markup like this, the Melody lexer would include the HTML comment in a TextStatement:
```
<span>
    Some text

    <!-- An HTML comment -->
</span>
```
The span tag would have only 1 child (TextStatement). This PR introduces a small fix in the Lexer, so that the span tag would not have 3 children (TextStatement, HtmlComment, TextStatement). See new test case.

This will be useful for pretty printing.

