### PR TITLE
Revert "Fix melody pakcages peer dependency mismatch"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## master
 
--   Fix peer dependency mismatch in melody packages [#143](https://github.com/trivago/melody/pull/143)
-
 ## 1.4.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "lint": "eslint ./packages/*/src",
         "prepare": "yarn build:release",
         "prettier": "prettier --write \"./packages/melody-*/src/**/*.[tj]s\"",
+        "update-peers": "./bin/updatePeerDependencies.js",
         "release": "./bin/release.sh",
         "release-ci": "./bin/ci-release.sh",
         "test": "TZ=Europe/London jest --coverage",

--- a/packages/melody-compiler/package.json
+++ b/packages/melody-compiler/package.json
@@ -18,11 +18,11 @@
     "random-seed": "^0.3.0"
   },
   "peerDependencies": {
-    "melody-idom": "link:../melody-idom",
-    "melody-parser": "link:../melody-parser",
-    "melody-runtime": "link:../melody-runtime",
-    "melody-traverse": "link:../melody-traverse",
-    "melody-types": "link:../melody-types"
+    "melody-idom": "^1.1.0",
+    "melody-parser": "^1.1.0",
+    "melody-runtime": "^1.1.0",
+    "melody-traverse": "^1.1.0",
+    "melody-types": "^1.1.0"
   },
   "devDependencies": {
     "melody-extension-core": "link:../melody-extension-core",

--- a/packages/melody-component/package.json
+++ b/packages/melody-component/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "melody-idom": "link:../melody-idom"
+    "melody-idom": "^1.1.0"
   }
 }

--- a/packages/melody-devtools/package.json
+++ b/packages/melody-devtools/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "melody-idom": "link:../melody-idom"
+    "melody-idom": "^1.1.0"
   }
 }

--- a/packages/melody-extension-core/package.json
+++ b/packages/melody-extension-core/package.json
@@ -16,10 +16,10 @@
     "shortid": "^2.2.6"
   },
   "peerDependencies": {
-    "melody-idom": "link:../melody-idom",
-    "melody-parser": "link:../melody-parser",
-    "melody-runtime": "link:../melody-runtime",
-    "melody-traverse": "link:../melody-traverse",
-    "melody-types": "link:../melody-types"
+    "melody-idom": "^1.1.0",
+    "melody-parser": "^1.1.0",
+    "melody-runtime": "^1.1.0",
+    "melody-traverse": "^1.1.0",
+    "melody-types": "^1.1.0"
   }
 }

--- a/packages/melody-hoc/package.json
+++ b/packages/melody-hoc/package.json
@@ -14,7 +14,7 @@
     "melody-component": "link:../melody-component"
   },
   "peerDependencies": {
-    "melody-idom": "link:../melody-idom"
+    "melody-idom": "1.1.0"
   },
   "devDependencies": {
     "melody-idom": "link:../melody-idom"

--- a/packages/melody-hooks/package.json
+++ b/packages/melody-hooks/package.json
@@ -11,7 +11,7 @@
     "author": "",
     "license": "Apache-2.0",
     "peerDependencies": {
-        "melody-idom":  "link:../melody-idom",
+        "melody-idom": "^1.1.0",
         "redux": "^3.6.0"
     }
 }

--- a/packages/melody-jest-transform/package.json
+++ b/packages/melody-jest-transform/package.json
@@ -18,10 +18,10 @@
     "melody-plugin-idom": "link:../melody-plugin-idom"
   },
   "peerDependencies": {
-    "melody-idom": "link:../melody-types",
-    "melody-parser": "link:../melody-parser",
-    "melody-runtime": "link:../melody-runtime",
-    "melody-traverse": "link:../melody-traverse",
-    "melody-types": "link:../melody-types"
+    "melody-idom": "^1.1.0",
+    "melody-parser": "^1.1.0",
+    "melody-runtime": "^1.1.0",
+    "melody-traverse": "^1.1.0",
+    "melody-types": "^1.1.0"
   }
 }

--- a/packages/melody-loader/package.json
+++ b/packages/melody-loader/package.json
@@ -17,7 +17,7 @@
     "melody-runtime": "link:../melody-runtime"
   },
   "peerDependencies": {
-    "melody-idom":  "link:../melody-idom"
+    "melody-idom": "1.1.0"
   },
   "devDependencies": {
     "melody-plugin-idom": "link:../melody-plugin-idom"

--- a/packages/melody-parser/package.json
+++ b/packages/melody-parser/package.json
@@ -15,6 +15,6 @@
     "melody-code-frame": "link:../melody-code-frame"
   },
   "peerDependencies": {
-    "melody-types":  "link:../melody-types"
+    "melody-types": "^1.1.0"
   }
 }

--- a/packages/melody-plugin-idom/package.json
+++ b/packages/melody-plugin-idom/package.json
@@ -13,6 +13,6 @@
     "babel-types": "^6.8.1"
   },
   "peerDependencies": {
-    "melody-types": "link:../melody-types"
+    "melody-types": "^1.1.0"
   }
 }

--- a/packages/melody-plugin-jsx/package.json
+++ b/packages/melody-plugin-jsx/package.json
@@ -13,7 +13,7 @@
     "babel-types": "^6.8.1"
   },
   "peerDependencies": {
-    "melody-traverse": "link:../melody-traverse",
-    "melody-types": "link:../melody-types"
+    "melody-traverse": "^1.1.0",
+    "melody-types": "^1.1.0"
   }
 }

--- a/packages/melody-plugin-load-functions/package.json
+++ b/packages/melody-plugin-load-functions/package.json
@@ -13,6 +13,6 @@
         "babel-types": "^6.8.1"
     },
     "peerDependencies": {
-        "melody-types":  "link:../melody-types"
+        "melody-types": "^1.1.0"
     }
 }

--- a/packages/melody-plugin-skip-if/package.json
+++ b/packages/melody-plugin-skip-if/package.json
@@ -13,6 +13,6 @@
     "babel-types": "^6.8.1"
   },
   "peerDependencies": {
-    "melody-types": "link:../melody-types"
+    "melody-types": "^1.1.0"
   }
 }

--- a/packages/melody-redux/package.json
+++ b/packages/melody-redux/package.json
@@ -13,6 +13,6 @@
     "melody-component": "link:../melody-component"
   },
   "peerDependencies": {
-    "melody-idom":  "link:../melody-idom"
+    "melody-idom": "^1.1.0"
   }
 }

--- a/packages/melody-runtime/package.json
+++ b/packages/melody-runtime/package.json
@@ -13,6 +13,6 @@
     "lodash": "^4.12.0"
   },
   "peerDependencies": {
-    "melody-idom":  "link:../melody-idom"
+    "melody-idom": "^1.2.0"
   }
 }

--- a/packages/melody-streams/package.json
+++ b/packages/melody-streams/package.json
@@ -11,6 +11,6 @@
     "author": "Patrick Gotthardt",
     "license": "Apache-2.0",
     "peerDependencies": {
-        "melody-idom":  "link:../melody-idom"
+        "melody-idom": "^1.1.0"
     }
 }

--- a/packages/melody-traverse/package.json
+++ b/packages/melody-traverse/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "melody-types": "link:../melody-types"
+    "melody-types": "^1.1.0"
   }
 }


### PR DESCRIPTION
Reverts trivago/melody#143

As I noticed, `link` is not working for peerDependecies. 