### PR TITLE
Add parsing of declarations like <!DOCTYPE html>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+-   `[melody-parser]`: Add parsing of declarations like `<!DOCTYPE html>`, along with new Parser option `ignoreDeclarations`.
+
 ## 1.5.0
 
 ### Features

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -375,6 +375,47 @@ describe('Parser', function() {
     });
 
     describe('when parsing HTML', function() {
+        it('should parse an HTML 5 doctype declaration', function() {
+            const node = parse('<!DOCTYPE html>', {
+                ignoreDeclarations: false,
+            });
+            expect(node).toMatchSnapshot();
+        });
+
+        it('should parse an HTML 5 doctype declaration with whitespace after !', function() {
+            const node = parse('<!   DOCTYPE html>', {
+                ignoreDeclarations: false,
+            });
+            expect(node).toMatchSnapshot();
+        });
+
+        it('should parse an HTML 4 doctype declaration', function() {
+            const node = parse(
+                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">',
+                {
+                    ignoreDeclarations: false,
+                }
+            );
+            expect(node).toMatchSnapshot();
+        });
+
+        it('should parse a doctype declaration containing an expression', function() {
+            const node = parse('<!DOCTYPE {{ theDocType }}>', {
+                ignoreDeclarations: false,
+            });
+            expect(node).toMatchSnapshot();
+        });
+
+        it('should throw a controlled error on an interrupted doctype declaration', function() {
+            try {
+                parse('<!DOCTYPE ', {
+                    ignoreDeclarations: false,
+                });
+            } catch (err) {
+                expect(err).toMatchSnapshot();
+            }
+        });
+
         it('should match a simple element', function() {
             const node = parse`<div>test</div>`;
             expect(node).toMatchSnapshot();

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -344,6 +344,93 @@ Object {
 }
 `;
 
+exports[`Parser when parsing HTML should parse a doctype declaration containing an expression 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "declarationType": "DOCTYPE",
+      "parts": Array [
+        Object {
+          "type": "PrintExpressionStatement",
+          "value": Object {
+            "name": "theDocType",
+            "type": "Identifier",
+          },
+        },
+      ],
+      "type": "Declaration",
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
+exports[`Parser when parsing HTML should parse an HTML 4 doctype declaration 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "declarationType": "DOCTYPE",
+      "parts": Array [
+        Object {
+          "name": "HTML",
+          "type": "Identifier",
+        },
+        Object {
+          "name": "PUBLIC",
+          "type": "Identifier",
+        },
+        Object {
+          "type": "StringLiteral",
+          "value": "-//W3C//DTD HTML 4.01//EN",
+        },
+        Object {
+          "type": "StringLiteral",
+          "value": "http://www.w3.org/TR/html4/strict.dtd",
+        },
+      ],
+      "type": "Declaration",
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
+exports[`Parser when parsing HTML should parse an HTML 5 doctype declaration 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "declarationType": "DOCTYPE",
+      "parts": Array [
+        Object {
+          "name": "html",
+          "type": "Identifier",
+        },
+      ],
+      "type": "Declaration",
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
+exports[`Parser when parsing HTML should parse an HTML 5 doctype declaration with whitespace after ! 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "declarationType": "DOCTYPE",
+      "parts": Array [
+        Object {
+          "name": "html",
+          "type": "Identifier",
+        },
+      ],
+      "type": "Declaration",
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
 exports[`Parser when parsing HTML should respect applyWhitespaceTrimming setting 1`] = `
 Object {
   "expressions": Array [
@@ -420,6 +507,13 @@ Object {
   ],
   "type": "SequenceExpression",
 }
+`;
+
+exports[`Parser when parsing HTML should throw a controlled error on an interrupted doctype declaration 1`] = `
+[Error: ERROR: Expected string, symbol, or expression
+  1 | <!DOCTYPE 
+
+Only strings or symbols can be part of a declaration]
 `;
 
 exports[`Parser when parsing Twig comments should match a comment 1`] = `

--- a/packages/melody-parser/README.md
+++ b/packages/melody-parser/README.md
@@ -37,6 +37,10 @@ If set to `true`, Twig comments will not be part of the resulting abstract synta
 
 If set to `true`, HTML comments will not be part of the resulting abstract syntax tree (AST). Defaults to `true`.
 
+### ignoreDeclarations (`true`)
+
+Declarations like `<!DOCTYPE html>` are not added to the parse tree if set to `true`.
+
 ### decodeEntities
 
 Character references/entities like `&#8206;` will be decoded if this is set to `true` (default). Otherwise, the string will be taken over verbatim to the AST.

--- a/packages/melody-parser/src/TokenTypes.js
+++ b/packages/melody-parser/src/TokenTypes.js
@@ -21,6 +21,7 @@ export const INTERPOLATION_START = 'interpolationStart';
 export const INTERPOLATION_END = 'interpolationEnd';
 export const STRING_START = 'stringStart';
 export const STRING_END = 'stringEnd';
+export const DECLARATION_START = 'declarationStart';
 export const COMMENT = 'comment';
 export const WHITESPACE = 'whitespace';
 export const HTML_COMMENT = 'htmlComment';

--- a/packages/melody-types/src/index.js
+++ b/packages/melody-types/src/index.js
@@ -377,3 +377,13 @@ export class HtmlComment extends Node {
 }
 type(HtmlComment, 'HtmlComment');
 visitor(HtmlComment, 'value');
+
+export class Declaration extends Node {
+    constructor(declarationType: String) {
+        super();
+        this.declarationType = declarationType;
+        this.parts = [];
+    }
+}
+type(Declaration, 'Declaration');
+visitor(Declaration, 'parts');


### PR DESCRIPTION
Previously, `melody-parser` would go into an endless loop when encountering a declaration like `<!DOCTYPE html>`. This PR fixes that by introducing a new `Declaration` node type. By default, these nodes are not added to the AST. They are only added if the new Parser option `ignoreDeclarations` is set to `false`.