### PR TITLE
Bugfix: Prevent Number tokens from ending in a dot "."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 -   `[melody-parser]`: Add parsing of declarations like `<!DOCTYPE html>`, along with new Parser option `ignoreDeclarations`.
+-   `[melody-parser]`: Fix bug where `1..5` results in a `MemberExpression` instead of a `BinaryRangeExpression`
 
 ## 1.5.0
 

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -260,7 +260,7 @@ describe('Parser', function() {
             expect(node).toMatchSnapshot();
         });
 
-        it('should handle the .. operator', function() {
+        it('should handle the .. operator without spaces', function() {
             const node = parse('{{ 1..5 }}', coreExtensions);
             const expression = node.expressions[0].value;
             expect(expression.type).toEqual('BinaryRangeExpression');

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -259,6 +259,12 @@ describe('Parser', function() {
             const node = p.parse();
             expect(node).toMatchSnapshot();
         });
+
+        it('should handle the .. operator', function() {
+            const node = parse('{{ 1..5 }}', coreExtensions);
+            const expression = node.expressions[0].value;
+            expect(expression.type).toEqual('BinaryRangeExpression');
+        });
     });
 
     const ifTag = {

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -1223,6 +1223,29 @@ Object {
 }
 `;
 
+exports[`Parser when parsing operators should handle the .. operator 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "type": "PrintExpressionStatement",
+      "value": Object {
+        "left": Object {
+          "type": "NumericLiteral",
+          "value": 1,
+        },
+        "operator": "..",
+        "right": Object {
+          "type": "NumericLiteral",
+          "value": 5,
+        },
+        "type": "BinaryRangeExpression",
+      },
+    },
+  ],
+  "type": "SequenceExpression",
+}
+`;
+
 exports[`Parser when parsing operators should match binary operators 1`] = `
 Object {
   "expressions": Array [

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -1223,29 +1223,6 @@ Object {
 }
 `;
 
-exports[`Parser when parsing operators should handle the .. operator 1`] = `
-Object {
-  "expressions": Array [
-    Object {
-      "type": "PrintExpressionStatement",
-      "value": Object {
-        "left": Object {
-          "type": "NumericLiteral",
-          "value": 1,
-        },
-        "operator": "..",
-        "right": Object {
-          "type": "NumericLiteral",
-          "value": 5,
-        },
-        "type": "BinaryRangeExpression",
-      },
-    },
-  ],
-  "type": "SequenceExpression",
-}
-`;
-
 exports[`Parser when parsing operators should match binary operators 1`] = `
 Object {
   "expressions": Array [

--- a/packages/melody-parser/src/Lexer.js
+++ b/packages/melody-parser/src/Lexer.js
@@ -587,7 +587,7 @@ export default class Lexer {
             }
             input.next();
         }
-        if (input.la(0) === '.') {
+        if (input.la(0) === '.' && isDigit(input.lac(1))) {
             input.next();
             while ((c = input.lac(0)) !== EOF) {
                 if (!isDigit(c)) {


### PR DESCRIPTION
Previously, the expression
```
{{ 1..5 }}
```
produced a `MemberExpression` with the object being `1` and the property being `5`. The reason was that `matchNumber()` in `Lexer.js`, when encountering a `.` in a number, prepared to read a series of decimals. In this case, it did not encounter anything, aborted, and produced a `Number` token with the text `1.`, which is a valid JavaScript number, but not a valid number in Twig (try, for example, `{{ 1. }}` on https://twigfiddle.com/).

This PR fixes this bug by looking ahead one additional character, and only going into decimal detection when there is a digit after the `.`.