### PR TITLE
Introduce generic twig tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+-   `[melody-parser]`: Introduce option `allowUnknownTags`, along with the `GenericTwigTag` node type
+
 ### Bug fixes
 
 ## 1.6.0

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -310,6 +310,31 @@ describe('Parser', function() {
             }).toThrowErrorMatchingSnapshot();
         });
 
+        it('should handle unknown tags when requested', function() {
+            const node = parse('{% exit 404 %}', {
+                allowUnknownTags: true,
+            });
+
+            const tagNode = node.expressions[0];
+            expect(tagNode.type).toBe('GenericTwigTag');
+            expect(tagNode.parts.length).toBe(1);
+            expect(tagNode.parts[0].type).toBe('NumericLiteral');
+            expect(tagNode.parts[0].value).toBe(404);
+        });
+
+        it('should parse expressions in unknown tags', function() {
+            const node = parse(
+                '{% exit a + b %}',
+                {
+                    allowUnknownTags: true,
+                },
+                coreExtensions
+            );
+
+            const tagNode = node.expressions[0];
+            expect(tagNode).toMatchSnapshot();
+        });
+
         it('should preserve whitespace control information', function() {
             const node = parse(
                 '{%- set count = 0 -%}',

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -335,6 +335,32 @@ describe('Parser', function() {
             expect(tagNode).toMatchSnapshot();
         });
 
+        it('should parse a Craft CMS "header" tag', function() {
+            const node = parse(
+                '{% header "Cache-Control: max-age=" ~ (expiry.timestamp - now.timestamp) %}',
+                {
+                    allowUnknownTags: true,
+                },
+                coreExtensions
+            );
+
+            const tagNode = node.expressions[0];
+            expect(tagNode).toMatchSnapshot();
+        });
+
+        it('should parse a Craft CMS "paginate" tag', function() {
+            const node = parse(
+                "{% paginate craft.entries.section('blog').limit(10) as pageInfo, pageEntries %}",
+                {
+                    allowUnknownTags: true,
+                },
+                coreExtensions
+            );
+
+            const tagNode = node.expressions[0];
+            expect(tagNode).toMatchSnapshot();
+        });
+
         it('should preserve whitespace control information', function() {
             const node = parse(
                 '{%- set count = 0 -%}',

--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -322,6 +322,20 @@ describe('Parser', function() {
             expect(tagNode.parts[0].value).toBe(404);
         });
 
+        it('should record the correct boundaries for unknown tags', function() {
+            const source = '{% exit 404 %}';
+            const node = parse(source, {
+                allowUnknownTags: true,
+            });
+
+            const tagNode = node.expressions[0];
+            const reproducedSource = source.substr(
+                tagNode.loc.start.index,
+                tagNode.loc.end.index
+            );
+            expect(reproducedSource).toEqual(source);
+        });
+
         it('should parse expressions in unknown tags', function() {
             const node = parse(
                 '{% exit a + b %}',

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -1740,7 +1740,7 @@ Object {
 }
 `;
 
-exports[`Parser when parsing tags should parse a Craft CMS "header" tag 1`] = `
+exports[`Parser when parsing tags should parse an unknown "header" tag 1`] = `
 Object {
   "parts": Array [
     Object {
@@ -1781,6 +1781,7 @@ Object {
       "wasImplicitConcatenation": false,
     },
   ],
+  "sections": Array [],
   "tagName": "header",
   "tagNameLoc": Object {
     "column": 3,
@@ -1793,7 +1794,7 @@ Object {
 }
 `;
 
-exports[`Parser when parsing tags should parse a Craft CMS "paginate" tag 1`] = `
+exports[`Parser when parsing tags should parse an unknown "paginate" tag 1`] = `
 Object {
   "parts": Array [
     Object {
@@ -1815,16 +1816,8 @@ Object {
           "callee": Object {
             "computed": false,
             "object": Object {
-              "computed": false,
-              "object": Object {
-                "name": "craft",
-                "type": "Identifier",
-              },
-              "property": Object {
-                "name": "entries",
-                "type": "Identifier",
-              },
-              "type": "MemberExpression",
+              "name": "entries",
+              "type": "Identifier",
             },
             "property": Object {
               "name": "section",
@@ -1860,6 +1853,7 @@ Object {
       "type": "Identifier",
     },
   ],
+  "sections": Array [],
   "tagName": "paginate",
   "tagNameLoc": Object {
     "column": 3,
@@ -1888,6 +1882,7 @@ Object {
       "type": "BinaryAddExpression",
     },
   ],
+  "sections": Array [],
   "tagName": "exit",
   "tagNameLoc": Object {
     "column": 3,

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -1740,6 +1740,138 @@ Object {
 }
 `;
 
+exports[`Parser when parsing tags should parse a Craft CMS "header" tag 1`] = `
+Object {
+  "parts": Array [
+    Object {
+      "left": Object {
+        "type": "StringLiteral",
+        "value": "Cache-Control: max-age=",
+      },
+      "operator": "~",
+      "right": Object {
+        "left": Object {
+          "computed": false,
+          "object": Object {
+            "name": "expiry",
+            "type": "Identifier",
+          },
+          "property": Object {
+            "name": "timestamp",
+            "type": "Identifier",
+          },
+          "type": "MemberExpression",
+        },
+        "operator": "-",
+        "right": Object {
+          "computed": false,
+          "object": Object {
+            "name": "now",
+            "type": "Identifier",
+          },
+          "property": Object {
+            "name": "timestamp",
+            "type": "Identifier",
+          },
+          "type": "MemberExpression",
+        },
+        "type": "BinarySubExpression",
+      },
+      "type": "BinaryConcatExpression",
+      "wasImplicitConcatenation": false,
+    },
+  ],
+  "tagName": "header",
+  "tagNameLoc": Object {
+    "column": 3,
+    "index": 3,
+    "line": 1,
+  },
+  "trimLeft": false,
+  "trimRight": false,
+  "type": "GenericTwigTag",
+}
+`;
+
+exports[`Parser when parsing tags should parse a Craft CMS "paginate" tag 1`] = `
+Object {
+  "parts": Array [
+    Object {
+      "arguments": Array [
+        Object {
+          "type": "NumericLiteral",
+          "value": 10,
+        },
+      ],
+      "callee": Object {
+        "computed": false,
+        "object": Object {
+          "arguments": Array [
+            Object {
+              "type": "StringLiteral",
+              "value": "blog",
+            },
+          ],
+          "callee": Object {
+            "computed": false,
+            "object": Object {
+              "computed": false,
+              "object": Object {
+                "name": "craft",
+                "type": "Identifier",
+              },
+              "property": Object {
+                "name": "entries",
+                "type": "Identifier",
+              },
+              "type": "MemberExpression",
+            },
+            "property": Object {
+              "name": "section",
+              "type": "Identifier",
+            },
+            "type": "MemberExpression",
+          },
+          "type": "CallExpression",
+        },
+        "property": Object {
+          "name": "limit",
+          "type": "Identifier",
+        },
+        "type": "MemberExpression",
+      },
+      "type": "CallExpression",
+    },
+    Object {
+      "name": "as",
+      "type": "Identifier",
+    },
+    Object {
+      "name": "pageInfo",
+      "type": "Identifier",
+    },
+    Object {
+      "tokenText": ",",
+      "tokenType": ",",
+      "type": "GenericToken",
+    },
+    Object {
+      "name": "pageEntries",
+      "type": "Identifier",
+    },
+  ],
+  "tagName": "paginate",
+  "tagNameLoc": Object {
+    "column": 3,
+    "index": 3,
+    "line": 1,
+  },
+  "trimLeft": false,
+  "trimRight": false,
+  "type": "GenericTwigTag",
+}
+`;
+
 exports[`Parser when parsing tags should parse expressions in unknown tags 1`] = `
 Object {
   "parts": Array [

--- a/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
+++ b/packages/melody-compiler/__tests__/__snapshots__/ParserSpec.js.snap
@@ -1740,6 +1740,34 @@ Object {
 }
 `;
 
+exports[`Parser when parsing tags should parse expressions in unknown tags 1`] = `
+Object {
+  "parts": Array [
+    Object {
+      "left": Object {
+        "name": "a",
+        "type": "Identifier",
+      },
+      "operator": "+",
+      "right": Object {
+        "name": "b",
+        "type": "Identifier",
+      },
+      "type": "BinaryAddExpression",
+    },
+  ],
+  "tagName": "exit",
+  "tagNameLoc": Object {
+    "column": 3,
+    "index": 3,
+    "line": 1,
+  },
+  "trimLeft": false,
+  "trimRight": false,
+  "type": "GenericTwigTag",
+}
+`;
+
 exports[`Parser when parsing tags should preserve whitespace control information 1`] = `
 Object {
   "expressions": Array [

--- a/packages/melody-parser/README.md
+++ b/packages/melody-parser/README.md
@@ -50,6 +50,135 @@ const abstractSyntaxTree = parse(code, coreExtension, customExtension);
 
 ## Options
 
+### allowUnknownTags (`false`)
+
+By default, the Melody parser throws an error when it encounters an unknown tag. This makes sense if you are preparing the generation of runnable code, because you don't know what to generate for unknown tags.
+
+However, if you only want to parse a Twig file, unknown tags are fine. In this case, set `allowUnknownTags` to `true`. The parser will now generate `GenericTwigTag` nodes in the AST for Twig tags it does not know. For example, imagine this custom `exit` tag:
+
+```
+{% exit 404 %}
+```
+
+If we allow Melody to parse it generically, it will return the following AST node (some properties stripped and reordered for clarity):
+
+```json
+Object {
+  "type": "GenericTwigTag",
+  "tagName": "exit",
+  "parts": Array [
+    Object {
+      "type": "NumericLiteral",
+      "value": 404,
+    },
+  ],
+  "sections": Array []
+}
+```
+
+We can see the node type `GenericTwigTag`, and the `tagName` property, which has the value `exit`. Let's look at the other two properties:
+
+-   `parts` is about what is going on inside the current Twig tag. In this example, there is only one more part, "404", which has been parsed as a `NumericLiteral`.
+-   `sections` is only relevant for "multiTags", i.e., sequences of Twig tags that belong together.
+
+As an example of a multi tag, let's look at the `nav` tag from [Craft CMS](https://docs.craftcms.com/v2/templating/nav.html):
+
+```
+{% nav items as item %}
+    <li>{{ item.name }}</li>
+{% endnav %}
+```
+
+Here, `nav` and `endnav` belong together. It's desirable to have this pair represented as one AST node, not two. The result looks like this (again, optimized and shortened for better readability):
+
+```json
+Object {
+  "type": "GenericTwigTag",
+  "tagName": "nav",
+  "parts": Array [
+    Object {
+      "name": "items",
+      "type": "Identifier",
+    },
+    Object {
+      "name": "as",
+      "type": "Identifier",
+    },
+    Object {
+      "name": "item",
+      "type": "Identifier",
+    },
+  ],
+  "sections": Array [
+    Object {
+      "type": "SequenceExpression",
+      "expressions": Array [
+        Object {
+          "name": "li",
+          "type": "Element",
+          "attributes": Array [],
+          "children": Array [
+            Object {
+              // item.name representation
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "type": "GenericTwigTag",
+      "tagName": "endnav",
+      "parts": Array [],
+      "sections": Array []
+    },
+  ],
+}
+```
+
+Some things to note about this example:
+
+-   The `nav` tag node has 3 entries in its `parts` array: `items`, `as`, and `item`, which are all `Identifier` nodes. Of course, semantically, only two of them (`items` and `item`) are real identifiers, whereas `as` is a keyword. However, since Melody does not know this tag, it does not distinguish between the two.
+-   The `nav` tag has 2 entries in its `sections` array: A `SequenceExpression` representing everything between `{% nav %}` and `{% endnav %}`, and a `GenericTwigTag` representing the `{% endnav %}` tag. This shows us that everything up to and including the closing `{% endnav %}` is _part of_ the `nav` tag. The `GenericTwigTag` representing the `{% endnav %}` tag is not an independent, top-level AST node, but part of the AST node representing the `{% nav %}` tag.
+
+However, in order to get this outcome, we have to tell Melody that `{% nav %}` and `{% endnav %}` belong together. This is done through the `multiTags` option.
+
+### multiTags (`{}`)
+
+In the section on `allowUnknownTags`, we saw that some tags belong together, like `{% nav %}` and `{% endnav %}`. In order to make this known to Melody, we use the `multiTags` option:
+
+```json
+{
+    "multiTags": {
+        "nav": ["endnav"],
+        "switch": ["case", "default", "endswitch"]
+    }
+}
+```
+
+We can see that `multiTags` is an object. Its keys are tag names. These tag names must come first in a sequence of tags, e.g., `{% nav %}` always comes before `{% endnav %}`, therefore we must not configure `multiTags` like this, with the order reverted:
+
+```json
+{
+    "multiTags": {
+        "endnav": ["nav"] // DON'T DO THIS!!!
+    }
+}
+```
+
+The values of the `multiTags` object are arrays containing the other tag names that can occur in the tag sequence started by the first tag name. Here, it's important that the tag name closing the sequence comes last. For example, when configuring for the [`switch` tag in Craft CMS](https://docs.craftcms.com/v2/templating/switch.html), `endswitch` has to come last:
+
+```json
+{
+    "multiTags": {
+        "switch": ["case", "default", "endswitch"]
+    }
+}
+```
+
+Other than that, the order of the other tag names (here, `case` and `default`) is not important. Moreover, you can add as many `multiTags` entries as you want.
+
+Note: If `multiTags` is non-empty, `allowUnknownTags` will automatically be set to `true`.
+
 ### ignoreComments (`true`)
 
 If set to `true`, Twig comments will not be part of the resulting abstract syntax tree (AST). Defaults to `true`.

--- a/packages/melody-parser/src/GenericMultiTagParser.js
+++ b/packages/melody-parser/src/GenericMultiTagParser.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { setStartFromToken, setEndFromToken } from './util';
+import { GenericTagParser } from './GenericTagParser';
+import * as Types from './TokenTypes';
+
+const tagMatchesOneOf = (tokenStream, tagNames) => {
+    for (let i = 0; i < tagNames.length; i++) {
+        if (tokenStream.test(Types.SYMBOL, tagNames[i])) {
+            return true;
+        }
+    }
+    return false;
+};
+
+export const createMultiTagParser = (tagName, subTags = []) => ({
+    name: 'genericTwigMultiTag',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            tagStartToken = tokens.la(-1);
+
+        if (subTags.length === 0) {
+            subTags.push('end' + tagName);
+        }
+
+        const twigTag = GenericTagParser.parse(parser, token);
+        let currentTagName = tagName;
+        const endTagName = subTags[subTags.length - 1];
+
+        while (currentTagName !== endTagName) {
+            // Parse next section
+            twigTag.sections.push(
+                parser.parse((tokenText, token, tokens) => {
+                    const hasReachedNextTag =
+                        token.type === Types.TAG_START &&
+                        tagMatchesOneOf(tokens, subTags);
+                    return hasReachedNextTag;
+                })
+            );
+            tokens.next(); // Get past "{%"
+
+            // Parse next tag
+            const childTag = GenericTagParser.parse(parser);
+            twigTag.sections.push(childTag);
+            currentTagName = childTag.tagName;
+        }
+
+        setStartFromToken(twigTag, tagStartToken);
+        setEndFromToken(twigTag, tokens.la(0));
+
+        return twigTag;
+    },
+});

--- a/packages/melody-parser/src/GenericTagParser.js
+++ b/packages/melody-parser/src/GenericTagParser.js
@@ -29,7 +29,18 @@ export const GenericTagParser = {
             if (currentToken.type === Types.TAG_END) {
                 break;
             } else {
-                twigTag.parts.push(parser.matchExpression());
+                try {
+                    twigTag.parts.push(parser.matchExpression());
+                } catch (e) {
+                    if (e.errorType === 'UNEXPECTED_TOKEN') {
+                        twigTag.parts.push(
+                            new n.GenericToken(e.tokenType, e.tokenText)
+                        );
+                        tokens.next();
+                    } else {
+                        throw e;
+                    }
+                }
             }
         }
         setStartFromToken(twigTag, tagStartToken);

--- a/packages/melody-parser/src/GenericTagParser.js
+++ b/packages/melody-parser/src/GenericTagParser.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { setStartFromToken, setEndFromToken } from './util';
+import * as Types from './TokenTypes';
+import * as n from 'melody-types';
+
+export const GenericTagParser = {
+    name: 'genericTwigTag',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            tagStartToken = tokens.la(-1);
+        let currentToken;
+
+        const twigTag = new n.GenericTwigTag(tokens.la(-1).text);
+        while ((currentToken = tokens.la(0))) {
+            if (currentToken.type === Types.TAG_END) {
+                break;
+            } else {
+                twigTag.parts.push(parser.matchExpression());
+            }
+        }
+        setStartFromToken(twigTag, tagStartToken);
+        setEndFromToken(twigTag, currentToken);
+
+        return twigTag;
+    },
+};

--- a/packages/melody-parser/src/GenericTagParser.js
+++ b/packages/melody-parser/src/GenericTagParser.js
@@ -13,15 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { setStartFromToken, setEndFromToken } from './util';
+import {
+    setStartFromToken,
+    setEndFromToken,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from './util';
 import * as Types from './TokenTypes';
 import * as n from 'melody-types';
 
 export const GenericTagParser = {
     name: 'genericTwigTag',
-    parse(parser, token) {
+    parse(parser) {
         const tokens = parser.tokens,
-            tagStartToken = tokens.la(-1);
+            tagStartToken = tokens.la(-2);
         let currentToken;
 
         const twigTag = new n.GenericTwigTag(tokens.la(-1).text);
@@ -45,6 +50,9 @@ export const GenericTagParser = {
         }
         setStartFromToken(twigTag, tagStartToken);
         setEndFromToken(twigTag, currentToken);
+
+        twigTag.trimLeft = hasTagStartTokenTrimLeft(tagStartToken);
+        twigTag.trimRight = hasTagEndTokenTrimRight(currentToken);
 
         return twigTag;
     },

--- a/packages/melody-parser/src/GenericTagParser.js
+++ b/packages/melody-parser/src/GenericTagParser.js
@@ -13,12 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    setStartFromToken,
-    setEndFromToken,
-    hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from './util';
+import { hasTagStartTokenTrimLeft, hasTagEndTokenTrimRight } from './util';
 import * as Types from './TokenTypes';
 import * as n from 'melody-types';
 
@@ -48,8 +43,7 @@ export const GenericTagParser = {
                 }
             }
         }
-        setStartFromToken(twigTag, tagStartToken);
-        setEndFromToken(twigTag, currentToken);
+        tokens.expect(Types.TAG_END);
 
         twigTag.trimLeft = hasTagStartTokenTrimLeft(tagStartToken);
         twigTag.trimRight = hasTagEndTokenTrimRight(currentToken);

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -436,8 +436,14 @@ export default class Parser {
         }
     }
 
-    error(options) {
-        this.tokens.error(options.title, options.pos, options.advice);
+    error(options, metadata = {}) {
+        this.tokens.error(
+            options.title,
+            options.pos,
+            options.advice,
+            1,
+            metadata
+        );
     }
 
     matchTag() {
@@ -594,15 +600,22 @@ export default class Parser {
                 } else if (token.type === Types.LBRACKET) {
                     node = this.matchMap();
                 } else {
-                    this.error({
-                        title:
-                            'Unexpected token "' +
-                            token.type +
-                            '" of value "' +
-                            token.text +
-                            '"',
-                        pos: token.pos,
-                    });
+                    this.error(
+                        {
+                            title:
+                                'Unexpected token "' +
+                                token.type +
+                                '" of value "' +
+                                token.text +
+                                '"',
+                            pos: token.pos,
+                        },
+                        {
+                            errorType: 'UNEXPECTED_TOKEN',
+                            tokenText: token.text,
+                            tokenType: token.type,
+                        }
+                    );
                 }
                 break;
         }

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -68,6 +68,10 @@ export default class Parser {
             },
             options
         );
+        // If there are custom multi tags, then we allow all custom tags
+        if (Object.keys(this.options.multiTags).length > 0) {
+            this.options.allowUnknownTags = true;
+        }
     }
 
     applyExtension(ext) {

--- a/packages/melody-parser/src/TokenStream.js
+++ b/packages/melody-parser/src/TokenStream.js
@@ -112,7 +112,7 @@ export default class TokenStream {
         );
     }
 
-    error(message, pos, advice, length = 1) {
+    error(message, pos, advice, length = 1, metadata = {}) {
         let errorMessage = `ERROR: ${message}\n`;
         errorMessage += codeFrame({
             rawLines: this.input.source,
@@ -128,7 +128,9 @@ export default class TokenStream {
         if (advice) {
             errorMessage += '\n\n' + advice;
         }
-        throw new Error(errorMessage);
+        const result = new Error(errorMessage);
+        Object.assign(result, metadata);
+        throw result;
     }
 }
 

--- a/packages/melody-types/src/index.js
+++ b/packages/melody-types/src/index.js
@@ -387,3 +387,12 @@ export class Declaration extends Node {
 }
 type(Declaration, 'Declaration');
 visitor(Declaration, 'parts');
+
+export class GenericTwigTag extends Node {
+    constructor(tagName: String) {
+        super();
+        this.tagName = tagName;
+        this.parts = [];
+    }
+}
+type(GenericTwigTag, 'GenericTwigTag');

--- a/packages/melody-types/src/index.js
+++ b/packages/melody-types/src/index.js
@@ -396,3 +396,12 @@ export class GenericTwigTag extends Node {
     }
 }
 type(GenericTwigTag, 'GenericTwigTag');
+
+export class GenericToken extends Node {
+    constructor(tokenType: String, tokenText: String) {
+        super();
+        this.tokenType = tokenType;
+        this.tokenText = tokenText;
+    }
+}
+type(GenericToken, 'GenericToken');

--- a/packages/melody-types/src/index.js
+++ b/packages/melody-types/src/index.js
@@ -393,6 +393,7 @@ export class GenericTwigTag extends Node {
         super();
         this.tagName = tagName;
         this.parts = [];
+        this.sections = [];
     }
 }
 type(GenericTwigTag, 'GenericTwigTag');


### PR DESCRIPTION
The main thing about this merge request is that it adds parsing capability for arbitrary Twig tags. This capability is activated through an option `allowUnknownTags`.

**Background:** If we only want to parse a Twig file, without executing it, we don't need custom parsers for all kinds of Twig tags. In this case, Melody can generate AST nodes of type `GenericTwigTag` for Twig tags it does not know. 

This is good enough for "lone" Twig tags like `{% exit 404 %}`. However, sometimes, pairs or even groups of Twig tags belong together. Example:

```
{% nav entry in entries %}
    <li>
        <a href="{{ entry.url }}">{{ entry.title }}</a>
        {% ifchildren %}
            <ul>
                {% children %}
            </ul>
        {% endifchildren %}
    </li>
{% endnav %}
```

Here, `{% nav %}` and `{% endnav %}`, as well as `{% ifchildren %}` and `{% endifchildren %}` belong together.

In order to have such tags adequately represented in the AST, they have to be made known to the Melody parser beforehand. The new option `multiTags` is used for that: 

```
{
    allowUnknownTags: true,
    multiTags: { 
        nav: ['endnav'],
        ifchildren: ['endifchildren'],
        switch: ['case', 'default', 'endswitch']
    },
}
```

`multiTags` is an object whose keys are the tag names of the first in a sequence of tags (here, `nav` and `ifchildren`), and whose values are arrays containing the other tag names that can occur in the sequence.  It's important that the concluding tag name comes last in this array. Other than that, the order does not matter.
