### PR TITLE
Fix enqueue component for test env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Bug fixes
 
+## 1.7.1
+
+### Bug fixes
+
+-   `[melody-idom]`: Allow consecutive updates in test environment.
+
 ## 1.7.0
 
 ### Features

--- a/packages/melody-idom/src/renderQueue.ts
+++ b/packages/melody-idom/src/renderQueue.ts
@@ -373,10 +373,7 @@ export function enqueueComponent(component: RenderableComponent): void {
     }
 
     addToQueue(component);
-    /* istanbul ignore else */
-    if (process.env.NODE_ENV === 'test') {
-        return;
-    }
+
     tick(flush);
 }
 


### PR DESCRIPTION
#### What changed in this PR:

`melody-streams` uses `enqueueComponent` to push the updates to DOM. (https://github.com/trivago/melody/blob/master/packages/melody-streams/src/component.js#L77) Currently, `enqueueComponent` blocks these consecutive updates in the test environment.  This PR allows these consecutive updates for the test environment as well. 

