### PR TITLE
Retain trimming information for conditional expressions

### DIFF
--- a/packages/melody-compiler/__tests__/ParserSpec.js
+++ b/packages/melody-compiler/__tests__/ParserSpec.js
@@ -596,6 +596,17 @@ describe('Parser', function() {
             expect(expression.trimLeft).toBe(true);
             expect(expression.trimRight).toBe(true);
         });
+
+        it('should put trimming information on a conditional expression', function () {
+            const node = parse(
+                `{{- ratingValue == 10 ? ratingValue : ratingValue -}}`,
+                coreExtensions
+            )
+
+            const tagNode = node.expressions[0]
+            expect(tagNode.trimLeft).toBe(true)
+            expect(tagNode.trimRight).toBe(true)
+        })
     });
 
     const addNotOperator = (parser, precedence = 500) => {

--- a/packages/melody-parser/src/Parser.js
+++ b/packages/melody-parser/src/Parser.js
@@ -536,11 +536,13 @@ export default class Parser {
             token = tokens.la(0);
         }
 
+        var result = expr;
         if (precedence === 0) {
             setEndFromToken(expr, tokens.la(-1));
+            result = this.matchConditionalExpression(expr);
+            // Update the local token variable because the stream pointer already advanced.
+            token = tokens.la(0);
         }
-        const result =
-            precedence === 0 ? this.matchConditionalExpression(expr) : expr;
 
         // Check for -}} (trim following whitespace)
         if (token.type === Types.EXPRESSION_END && token.text.startsWith('-')) {


### PR DESCRIPTION
Commit https://github.com/trivago/prettier-plugin-twig-melody/commit/2d59a7f9c014c236318f870d87fdfe2b9d6a91e1 introduced a test case for unexpected formatting behaviour that turned out to be an issue in the Twig parser.